### PR TITLE
Update numbers from AG for 19.03.2020

### DIFF
--- a/COVID19_Fallzahlen_Kanton_AG_total.csv
+++ b/COVID19_Fallzahlen_Kanton_AG_total.csv
@@ -13,3 +13,4 @@ Date,Area,TotalTestedCases,TotalConfCases,TotalPosTests1,TotalCured,TotalDeaths
 16.03.2020,Canton_AG,,52,,4,
 17.03.2020,Canton_AG,,67,,4,
 18.03.2020,Canton_AG,,101,,4,
+19.03.2020,Canton_AG,,118,,,


### PR DESCRIPTION
Source: https://www.ag.ch/media/kanton_aargau/themen_1/coronavirus_1/lagebulletins/200319_KFS_Coronavirus_Lagebulletin_15.pdf

Interesting note in today's PDF:

> Gemäss der Weisung des BAG werden die Anzahl der Geheilten nicht mehr erfasst.