### PR TITLE
adding Uri

### DIFF
--- a/COVID19_Fallzahlen_Kanton_UR_total.csv
+++ b/COVID19_Fallzahlen_Kanton_UR_total.csv
@@ -1,0 +1,3 @@
+Date,Area,TotalTestedCases,TotalConfCases,TotalPosTests1,TotalCured,TotalDeaths
+12.03.2020,Canton_UR,,2,,,
+19.03.2020,Canton_UR,,7,,,


### PR DESCRIPTION
Taken from
https://www.ur.ch/mmdirektionen/63458
"m Kanton Uri sind zwei bestätigte Fälle des neuen Coronavirus aufgetreten. Auch der Referenztest des Genfer Labors hat den Erstbefund beiden Fällen bestätigt. Die Patienten sind unabhängig vonein­ander erkrankt."
and 
https://www.ur.ch/themen/2920
"In Uri sind zurzeit (Stand 19. März 2020, 12.00 Uhr) 7 Fälle positiv auf Coronavirus getestet worden."