### PR TITLE
Update COVID19_Fallzahlen_Kanton_SO_total.csv

### DIFF
--- a/fallzahlen_kanton_total_csv/COVID19_Fallzahlen_Kanton_SO_total.csv
+++ b/fallzahlen_kanton_total_csv/COVID19_Fallzahlen_Kanton_SO_total.csv
@@ -1,2 +1,3 @@
 date,time,abbreviation_canton_and_fl,ncumul_tested,ncumul_conf,ncumul_hosp,ncumul_ICU,ncumul_vent,ncumul_released,ncumul_deceased,source
 2020-03-06,12:00,SO,,1,,,,,,https://so.ch/startseite/aktuell/news/erster-laborbestaetigter-covid-19-fall-im-kanton-solothurn/?tx_news_pi1%5Bcontroller%5D=News&tx_news_pi1%5Baction%5D=detail&cHash=3074bbdc8f0fcdcb9f1e11a21fc05e73
+2020-03-18,,SO,,43,,,,,,https://www.oltnertagblatt.ch/solothurn/kanton-solothurn/zivilschuetzer-kontrollieren-wer-in-die-solothurner-spitaeler-rein-will-137174885


### PR DESCRIPTION
Die beste Quelle fuer SO die ich finden konnte, alternativ sagt der Bund gester https://web.archive.org/web/20200321025447/http://m.derbund.ch/articles/26459141 nur 19 Faelle aber die haben auch keine Quelle. Pro 100k Einwohner waeren das 43 / 2.73 = 15.75 und das ist konsistent mit dem letzten Situationsbericht des BAG (16.8 pro 100k am 20. Maerz)

Die Quelle ist etwas unklar "Aktuell gibt es 43 bestätigte Corona-Fälle." aber im Kontext bezieht sich wohl auf den ganzen Kanton 