### PR TITLE
Fixed scraper for AG

### DIFF
--- a/.github/workflows/run_ag_scraper.yml
+++ b/.github/workflows/run_ag_scraper.yml
@@ -1,0 +1,38 @@
+name: Run AG scraper
+
+on:
+  schedule:
+    - cron:  '*/10 14-23 * * *'
+
+jobs:
+  run_scraper:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        sudo apt-get install sqlite3
+        
+    - name: Scrape new data
+      env:
+        SCRAPER_KEY: AG
+        SCRAPER_SOURCE: https://www.ag.ch/de/themen_1/coronavirus_2/alle_ereignisse/alle_ereignisse_1.jsp
+      run: |
+        ./scrapers/run_scraper.sh
+        
+    # Commit to repo with updated file
+    - uses: stefanzweifel/git-auto-commit-action@v4.1.1
+      with:
+        commit_message: Update COVID19_Fallzahlen_Kanton_AG_total.csv from scraper
+        branch: ${{ github.head_ref }}

--- a/scrapers/parse_scrape_output.py
+++ b/scrapers/parse_scrape_output.py
@@ -134,6 +134,12 @@ def parse_date(d):
     assert 1 <= int(mo[3]) <= 23
     # 24.3. / 10h
     return f"2020-{int(mo[2]):02d}-{int(mo[1]):02d}T{int(mo[3]):02d}:00"
+  mo = re.search(r'^(\d\d\d\d-\d\d-\d\d)T?(\d\d:\d\d)(:\d\d)?$', d)
+  if mo:
+    # 2020-03-23T15:00:00
+    # 2020-03-23 15:00:00
+    # 2020-03-23 15:00
+    return f"{mo[1]}T{mo[2]}"
   assert False, f"Unknown date/time format: {d}"
 
 
@@ -145,6 +151,8 @@ cases=None
 deaths=None
 recovered=None
 hospitalized=None
+icu=None
+vent=None
 
 try:
   i = 0
@@ -175,6 +183,12 @@ try:
       continue
     if k.startswith("Hospitalized"):
       hospitalized = int(v)
+      continue
+    if k.startswith("ICU"):
+      icu = int(v)
+      continue
+    if k.startswith("Vent"):
+      vent = int(v)
       continue
     assert False, f"Unknown data on line {i}: {l}"
 

--- a/scrapers/scrape_ag.sh
+++ b/scrapers/scrape_ag.sh
@@ -5,26 +5,24 @@ DIR="$(cd "$(dirname "$0")" && pwd)"  # " # To make editor happy
 
 echo AG
 
-# From latest PDF:
-#URL=$("${DIR}/download.sh" "https://www.ag.ch/de/themen_1/coronavirus_2/lagebulletins/lagebulletins_1.jsp" | sed -E -e 's/<li>/\n<li>/g' | grep Bulletin | grep pdf | grep href | awk -F '"' '{print $6;}' | head -1)
-#d=$("${DIR}/download.sh" "https://www.ag.ch/${URL}" | pdftotext - - | egrep -A 2 "(Aarau, .+Uhr|Stand [A-Za-z]*, [0-9]+)")  # " # To make my editor happy.
-
 # From the new website:
-d=$("${DIR}/download.sh" "https://www.ag.ch/de/themen_1/coronavirus_2/coronavirus.jsp" | egrep 'Aktuelles Lagebulletin|bestätigte Fälle')
+d=$("${DIR}/download.sh" "https://www.ag.ch/de/themen_1/coronavirus_2/alle_ereignisse/alle_ereignisse_1.jsp" | egrep 'Neues Lagebulletin')
 echo "Scraped at: $(date --iso-8601=seconds)"
 
-# <main id="main" class="main"><!--googleon: index--><!--googleon: snippet--><!--googleoff: index--><!--googleoff: snippet--><div class="pagesection"><div class="pagesection__inner"><div ><div class="subc contentcol"><nav class="breadcrumb js-breadcrumb" aria-labelledby="breadcrumb__title"><h2 id="breadcrumb__title" class="breadcrumb__title">Sie sind hier:</h2><ul class="breadcrumb__container js-breadcrumb__container"><li class="breadcrumb__item breadcrumb__item--home"><a class="breadcrumb__link" href="/de/startseite_portal/startseite_portal.jsp" title="Startseite Kanton Aargau">Aargau</a></li><li class="breadcrumb__item"><span class="sprite sprite--chevron breadcrumb__divider"><svg viewBox="0 0 500 500"><use xlink:href="#svgicon-chevron"></use></svg></span><a class="breadcrumb__link" href="/de/themen_1/themen.jsp">Themen</a></li><li class="breadcrumb__item breadcrumb__item--current"><span class="sprite sprite--chevron breadcrumb__divider"><svg viewBox="0 0 500 500"><use xlink:href="#svgicon-chevron"></use></svg></span>Coronavirus</li></ul><button type="button" class="breadcrumb__scrollbutton breadcrumb__scrollbutton--left js-breadcrumb__left" title="Höhere Navigationsebenen anzeigen" aria-hidden="true"><span class="sprite sprite--start breadcrumb__scrollbutton__sprite breadcrumb__scrollbutton--left__sprite"><svg viewBox="0 0 500 500"><use xlink:href="#svgicon-start"></use></svg></span></button><button type="button" class="breadcrumb__scrollbutton breadcrumb__scrollbutton--right js-breadcrumb__right" title="Tiefere Navigationsebenen anzeigen" aria-hidden="true"><span class="sprite sprite--end breadcrumb__scrollbutton__sprite breadcrumb__scrollbutton--right__sprite"><svg viewBox="0 0 500 500"><use xlink:href="#svgicon-end"></use></svg></span></button><div class="clearfix"></div></nav><!--googleon: index--><!--googleon: snippet--><h1 class="pagetitle">Coronavirus: das Wichtigste im &Uuml;berblick</h1><div class="subcolumns"><div class="c66l"><article class="subcl"><figure aria-labelledby="image_1740244" class="image"><div class="image__inner"><picture><source id="image_1740244" srcset="/media/kanton_aargau/dgs/bilder_4/gesundheit/Corona_teaser_small.png 421w,/media/kanton_aargau/dgs/bilder_4/gesundheit/Corona_teaser_medium.png 842w,/media/kanton_aargau/dgs/bilder_4/gesundheit/Corona_teaser_large.png 1280w" sizes="(max-width: 600px) 98vw, (max-width: 991px) 65vw, 50vw" /><img id="image_1740244" src="/media/kanton_aargau/dgs/bilder_4/gesundheit/Corona_teaser_medium.png" alt="" /></picture></div></figure><p class="leadtext">Alle wichtigen Informationen zum Coronavirus - von Medienmitteilungen &uuml;ber Informations- und Faktenbl&auml;tter bis hin zu Hygienevorschriften und Lagebulletins finden Sie auf den nachfolgenden Seiten. Bei Fragen steht Ihnen ein Kontaktformular zur Verf&uuml;gung.</p><section class="contentcol__section"></section><section class="contentcol__section"><h2 class="h2" id="1741779">Aktuelles Lagebulletin vom Montag, 23. M&auml;rz 2020, 15 Uhr</h2><h3 class="h3">Im Kanton Aargau liegen zurzeit 241 best&auml;tigte F&auml;lle vor (72 mehr als Freitag). 10 Personen sind zurzeit hospitalisiert. 3 Personen werden auf Intensivstationen behandelt, wovon 2 k&uuml;nstlich beatmet werden m&uuml;ssen.</h3><p>Das Bundesamt f&uuml;r Gesundheit (BAG) hat in der Schweiz bisher 7'245 Ansteckungen best&auml;tigt (665 weitere wahrscheinlich). Bisher sind in der Schweiz 98 Personen an den Folgen des Coronavirus verstorben.</p><p><a target="_blank" class="mime-pdf" href="/media/kanton_aargau/themen_1/coronavirus_1/lagebulletins/200323_KFS_Coronavirus_Lagebulletin_17.pdf"><span class="link__text">Lagebulletin Nr. 17 vom Montag, 23. M&auml;rz 2020, 15 Uhr (PDF, 3 Seiten, 937 KB)</span></a></p></section><section class="teasercollection teasercollection--overview teasercollection--equalheight"><ol class="teasercollection__items"><li class="teasercollection__item"><article class="teaser"><a class="teaser__link" href="/de/themen_1/coronavirus_2/informationen_zum_schulbetrieb/informationen_zum_schulbetrieb.jsp"><div class="teaser__content"><h2 class="teaser__heading"><span class="teaser__title">Informationen zum Schulbetrieb</span></h2><p class="teaser__description">Alle Schulen im Kanton Aargau bleiben bis 4. April geschlossen.</p><span class="teaser__cta link" aria-hidden="true">Mehr<span class='sprite sprite--chevron '><svg viewBox="0 0 500 500"><use xlink:href='#svgicon-chevron' /></svg></span></span></div></a></article>
-# ...
-# <h2 class="h2" id="1741779">Aktuelles Lagebulletin vom Montag, 23. M&auml;rz 2020, 15 Uhr</h2><h3 class="h3">Im Kanton Aargau liegen zurzeit 241 best&auml;tigte F&auml;lle vor (72 mehr als Freitag). 10 Personen sind zurzeit hospitalisiert. 3 Personen werden auf Intensivstationen behandelt, wovon 2 k&uuml;nstlich beatmet werden m&uuml;ssen.</h3>
-
 echo -n "Date and time: "
-echo "$d" | egrep "Aktuelles .*vom" | sed -E -e 's/^.*vom [A-Za-z]+, (.+ Uhr)<\/h2>.*$/\1/' | head -1
+echo "$d" | sed -E -e 's/Neues Lagebulletin/\n/g' | egrep 'class="timeline__time" datetime="00.*00"' | sed -E -e 's/^.*class="timeline__time" datetime="00(.*00)".*$/\1/' | head -1
 
 echo -n "Confirmed cases: "
-echo "$d" | egrep "zurzeit [0-9]+ best(ä|&auml;)tigte F(ä|&auml;)lle" | sed -E -e 's/^.*zurzeit ([0-9]+) best(ä|&auml;)tigte F(ä|&auml;)lle.*$/\1/' | head -1
+echo "$d" | sed -E -e 's/Neues Lagebulletin/\n/g' | egrep "zurzeit [0-9]+ best(ä|&auml;)tigte F(ä|&auml;)lle" | sed -E -e 's/^.*zurzeit ([0-9]+) best(ä|&auml;)tigte F(ä|&auml;)lle.*$/\1/' | head -1
 
 echo -n "Hospitalized: "
-echo "$d" | egrep "hospitalisiert" | sed -E -e 's/^.* ([0-9]+) Person(en)? sind zurzeit hospitalisiert.*$/\1/' | head -1
+echo "$d" | sed -E -e 's/Neues Lagebulletin/\n/g' | egrep "[0-9]+ Person(en)? sind zurzeit hospitalisiert" | sed -E -e 's/^.* ([0-9]+) Person(en)? sind zurzeit hospitalisiert.*$/\1/' | head -1
 
-#echo -n "ICU: "
-#
+echo -n "ICU: "
+echo "$d" | sed -E -e 's/Neues Lagebulletin/\n/g' | egrep "[0-9]+ Person(en)? werden auf Intensivstationen behandelt" | sed -E -e 's/^.* ([0-9]+) Person(en)? werden auf Intensivstationen behandelt.*$/\1/' | head -1
+
+echo -n "Vent: "
+echo "$d" | sed -E -e 's/Neues Lagebulletin/\n/g' | egrep "[0-9]+ Person(en)? k(ü|&uuml;)nstlich beatmet werden" | sed -E -e 's/^.* ([0-9]+) Person(en)? k(ü|&uuml;)nstlich beatmet werden.*$/\1/' | head -1
+
+echo -n "Deaths: "
+echo "$d" | sed -E -e 's/Neues Lagebulletin/\n/g' | sed -E -e 's/zwei/2/g' | egrep "[0-9]+ Person(en)? an den Folgen des Coronavirus verstorben" | sed -E -e 's/^.* ([0-9]+) Person(en)? an den Folgen des Coronavirus verstorben.*$/\1/' | head -1


### PR DESCRIPTION
AG has published a new page which lists all new information and is easier to parse: https://www.ag.ch/de/themen_1/coronavirus_2/alle_ereignisse/alle_ereignisse_1.jsp

Running the cron every 10 minutes after 15:00 (14:00 in UTC).