### PR TITLE
Update Canton GE as of 25/03/2020

### DIFF
--- a/fallzahlen_kanton_total_csv/COVID19_Fallzahlen_Kanton_GE_total.csv
+++ b/fallzahlen_kanton_total_csv/COVID19_Fallzahlen_Kanton_GE_total.csv
@@ -27,4 +27,5 @@ date,time,abbreviation_canton_and_fl,ncumul_tested,ncumul_conf,ncumul_hosp,ncumu
 2020-03-21,,GE,,1128,145,25,107,,10,https://www.ge.ch/document/covid-19-situation-epidemiologique-geneve/telecharger,13,24,
 2020-03-22,,GE,,1203,179,36,137,,9,https://www.ge.ch/document/covid-19-situation-epidemiologique-geneve/telecharger,6,36,4
 2020-03-23,12:00,GE,,1509,214,43,160,,9,https://www.ge.ch/document/covid-19-situation-epidemiologique-geneve/telecharger,11,41,
-2020-03-24,12:00,GE,,1510,238,41,176,,12,https://www.ge.ch/document/covid-19-situation-epidemiologique-geneve/telecharger,21,41,
+2020-03-24,12:00,GE,,1598,238,41,176,103,12,https://www.ge.ch/document/covid-19-situation-epidemiologique-geneve/telecharger,21,41,
+2020-03-25,12:00,GE,,1604,258,50,190,122,15,https://www.ge.ch/document/covid-19-situation-epidemiologique-geneve/telecharger,21,,

--- a/fallzahlen_kanton_total_csv/COVID19_Fallzahlen_Kanton_GE_total.csv
+++ b/fallzahlen_kanton_total_csv/COVID19_Fallzahlen_Kanton_GE_total.csv
@@ -28,4 +28,4 @@ date,time,abbreviation_canton_and_fl,ncumul_tested,ncumul_conf,ncumul_hosp,ncumu
 2020-03-22,,GE,,1203,179,36,137,,9,https://www.ge.ch/document/covid-19-situation-epidemiologique-geneve/telecharger,6,36,4
 2020-03-23,12:00,GE,,1509,214,43,160,,9,https://www.ge.ch/document/covid-19-situation-epidemiologique-geneve/telecharger,11,41,
 2020-03-24,12:00,GE,,1598,238,41,176,103,12,https://www.ge.ch/document/covid-19-situation-epidemiologique-geneve/telecharger,21,41,
-2020-03-25,12:00,GE,,1604,258,50,190,122,15,https://www.ge.ch/document/covid-19-situation-epidemiologique-geneve/telecharger,21,,
+2020-03-25,12:00,GE,,1604,258,50,190,122,15,https://www.ge.ch/document/covid-19-situation-epidemiologique-geneve/telecharger,18,,


### PR DESCRIPTION
Update Canton GE status from the usual source (https://www.ge.ch/document/covid-19-situation-epidemiologique-geneve/telecharger). I've not added the _ncumul_ICU_intub_ count because it may be false in the official report (going down from 41 to 2 in one day is a bit suspect).