### PR TITLE
Make sure there is only one entry per day

### DIFF
--- a/scrapers/populate_database.py
+++ b/scrapers/populate_database.py
@@ -37,7 +37,7 @@ try:
             ncumul_released integer,
             ncumul_deceased integer,
             source text,
-            UNIQUE(date, time, abbreviation_canton_and_fl)
+            UNIQUE(date, abbreviation_canton_and_fl)
         )
         '''
     )


### PR DESCRIPTION
This only applies to CSVs that are updated via scraper. While it's
technically possible to have multiple values per day, it's hard to
ensure correctly from the scrapers. Some scrapers may not be able to
determine the time and will default to an empty string. If there is
already an entry with a time in place, this could lead to duplicate
entries.