### PR TITLE
Convert encoding of OW page to UTF-8

### DIFF
--- a/scrapers/scrape_ow.sh
+++ b/scrapers/scrape_ow.sh
@@ -4,7 +4,7 @@ set -e
 DIR="$(cd "$(dirname "$0")" && pwd)"  # " # To make editor happy
 
 echo OW
-d=$("${DIR}/download.sh" "https://www.ow.ch/de/verwaltung/dienstleistungen/?dienst_id=5962" | egrep '>Stand |ist bei [0-9]+ Personen')
+d=$("${DIR}/download.sh" "https://www.ow.ch/de/verwaltung/dienstleistungen/?dienst_id=5962" | iconv --from-code=windows-1252 --to-code=utf-8 | egrep '>Stand |ist bei [0-9]+ Personen')
 echo "Scraped at: $(date --iso-8601=seconds)"
 
 #<p class="object-pages-img"><img src="../../images/5e73948a8f49f.jpg"  alt="Kampagne BAG" style="width:600;height:293;border:0;" /></p><br /><div class="object-pages-description"><p class="icmsPContent icms-wysiwyg-first"><em>Stand 23.03.2020</em></p>


### PR DESCRIPTION
OW site apparently is using non-UTF-8 encoding as of 2020-03-24.
Not sure how it was before.

So convert it manually to UTF-8. Otherwise, grep will be complaining and
not output proper output, as it will think the file is binary.

Once we port all to Python, we could be smarter, and detect encoding
dynamically based on HTML headers probably.

Closes: https://github.com/openZH/covid_19/issues/157