### PR TITLE
Fix scraper for SZ and port it to Python

### DIFF
--- a/scrapers/scrape_ow.sh
+++ b/scrapers/scrape_ow.sh
@@ -4,7 +4,7 @@ set -e
 DIR="$(cd "$(dirname "$0")" && pwd)"  # " # To make editor happy
 
 echo OW
-d=$("${DIR}/download.sh" "https://www.ow.ch/de/verwaltung/dienstleistungen/?dienst_id=5962" | egrep '>Stand |ist bei [0-9]+ Personen')
+d=$("${DIR}/download.sh" "https://www.ow.ch/de/verwaltung/dienstleistungen/?dienst_id=5962" | iconv --from-code=windows-1252 --to-code=utf-8 | egrep '>Stand |ist bei [0-9]+ Personen')
 echo "Scraped at: $(date --iso-8601=seconds)"
 
 #<p class="object-pages-img"><img src="../../images/5e73948a8f49f.jpg"  alt="Kampagne BAG" style="width:600;height:293;border:0;" /></p><br /><div class="object-pages-description"><p class="icmsPContent icms-wysiwyg-first"><em>Stand 23.03.2020</em></p>

--- a/scrapers/scrape_sz.sh
+++ b/scrapers/scrape_sz.sh
@@ -1,25 +1,15 @@
-#!/bin/sh
-set -e
+#!/usr/bin/env python3
 
-DIR="$(cd "$(dirname "$0")" && pwd)"  # " # To make editor happy
+import scrape_common as sc
 
-echo SZ
+print('SZ')
 
-#       <h2>Medienmitteilungen des kantonalen Führungsstabs</h2> 
-#       <ul> 
-#        <li><a href="https://www.sz.ch/public/upload/assets/45637/MM_KFS_Corona_17_3_2020.pdf">Medienmitteilung vom 17. März 2020</a></li> 
+d = sc.download('https://www.sz.ch/behoerden/information-medien/medienmitteilungen/coronavirus.html/72-416-412-1379-6948')
+sc.timestamp()
 
-URL=$("${DIR}/download.sh" 'https://www.sz.ch/behoerden/information-medien/medienmitteilungen/coronavirus.html/72-416-412-1379-6948' | grep -A 3 "Medienmitteilungen des kantonalen Führungsstabs" | grep "<li>" | head -1 | awk -F '"' '{print $2;}')
-d=$("${DIR}/download.sh" "${URL}" | pdftotext - - | grep "bestätigte Fälle|Schwyz, .+ 202")
-echo "Scraped at: $(date --iso-8601=seconds)"
+# 2020-03-25
+"""        <li> <p>Aktuelle Fallzahlen im Kanton Schwyz (Stand: 25. März 2020): 99 Infizierte, 10 Genesene</p> </li> """
 
-# Schwyz, 17. März 2020
-# Im Kanton Schwyz sind aktuell 13 bestätigte Fälle registriert.
-
-echo -n "Date and time: "
-echo "$d" | egrep "Schwyz, .* 202" | sed -E -e 's/^.*Schwyz, (.+ 202[2-9]).*$/\1/'
-
-echo -n "Confirmed cases: "
-echo "$d" | egrep "aktuell" | sed -E -e 's/^.*aktuell ([0-9]+) bestätigte Fälle.*$/\1/'
-
-# The latest PDF from 2020-03-17 doesn't mention numbers. Some previous did tho.
+print('Date and time:', sc.find(r'Stand: ([^)]+)\)', d))
+print('Confirmed cases:', sc.find(r': ([0-9]+) Infizierte', d))
+print('Recovered:', sc.find(r', ([0-9]+) Genesene', d))


### PR DESCRIPTION
It uses now more direct approach,
and no indirect link following or pdf conversion.

Also implemented in Python now.

Please merge only after: https://github.com/openZH/covid_19/pull/177
because I messed up branches.

Closes: https://github.com/openZH/covid_19/issues/164