### PR TITLE
Add a timestamp to FAILED in meta_scrape.sh

### DIFF
--- a/scrapers/meta_scrape.sh
+++ b/scrapers/meta_scrape.sh
@@ -30,6 +30,6 @@ for s in ./scrape_*.sh;
 do
   if ! ./$s | ./parse_scrape_output.py 2>/dev/null; then
     a=$(echo "$s" | sed -E -e 's/^.*scrape_(..)\..*$/\1/' | tr a-z A-Z) # ' # To make my editor happy.
-    echo "$a" - - - FAILED
+    echo "$a" - - - FAILED "$(date --iso-8601=seconds)"
   fi
 done


### PR DESCRIPTION
It is not perfect, because it kind of hides the time of data retrival,
but ok.

We should show a bit more failure details in the meta_scrape if possible.

Closes: https://github.com/openZH/covid_19/issues/206