### PR TITLE
Use 'echo -e' in the VD scraper so it works with bash

### DIFF
--- a/scrapers/scrape_vd.sh
+++ b/scrapers/scrape_vd.sh
@@ -30,10 +30,10 @@ echo "Scraped at: $(date --iso-8601=seconds)"
 
 
 echo -n "Date and time: "
-echo "$d" | tail -1 | awk '{print $1;}'
+echo -e "$d" | tail -1 | awk '{print $1;}'
 
 echo -n "Confirmed cases: "
-echo "$d" | tail -1 | awk '{print $5;}'
+echo -e "$d" | tail -1 | awk '{print $5;}'
 
 echo -n "Deaths: "
-echo "$d" | tail -1 | awk '{print $4;}'
+echo -e "$d" | tail -1 | awk '{print $4;}'


### PR DESCRIPTION
The issue is somewhere before that with '\t', but I don't know where.

Using `echo -e` makes it work fine in both bash and dash.

This is just a temporary solution, before porting this last one to Python.

Closes: https://github.com/openZH/covid_19/issues/205