### PR TITLE
Add spelled_out_numbers_map, scrape deaths for LU

### DIFF
--- a/scrapers/scrape_common.py
+++ b/scrapers/scrape_common.py
@@ -7,6 +7,24 @@ import os
 import subprocess
 import re
 
+spelledOutNumbersMap = {
+  'eins': 1,
+  'einen': 1,
+  'zwei': 2,
+  'drei': 3,
+  'vier': 4,
+  'fünf': 5,
+  'f&uuml;nf': 5,
+  'sechs': 6,
+  'sieben': 7,
+  'acht': 8,
+  'neun': 9,
+  'zehn': 10,
+  'elf': 11,
+  'zwölf': 12,
+  'zw&ouml;lf':12
+}
+
 def download(url, encoding='utf-8'):
   """curl like"""
   print("Downloading:", url)
@@ -38,3 +56,17 @@ def find(pattern, d, group=1, flags=re.I):
 def timestamp():
   now = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).astimezone()
   print("Scraped at:", now.isoformat(timespec='seconds'))
+
+def represents_int(s):
+    try:
+        int(s)
+        return True
+    except ValueError:
+        return False
+
+def int_or_word(x):
+  if x in spelledOutNumbersMap:
+    return spelledOutNumbersMap[x]
+  elif represents_int(x):
+    return int(x)
+  return None

--- a/scrapers/scrape_lu.sh
+++ b/scrapers/scrape_lu.sh
@@ -15,3 +15,9 @@ d = sc.filter(r'Im Kanton Luzern gibt es', d)
 
 print('Date and time:', sc.find(r'Stand: (.+)(Uhr)?\)', d))
 print('Confirmed cases:', sc.find('gibt es ([0-9]+) best(&auml;|ä)tige F(&auml;|ä)lle', d))
+
+deathsString = sc.find('Es gibt (.*) Todesf(&auml;|ä)lle', d)
+
+deaths = sc.int_or_word(deathsString)
+if not deaths is None:
+  print('Deaths:', deaths)


### PR DESCRIPTION
Add spelled_out_numbers_map, scrape deaths for LU

This change adds an associative array to map spelled out numbers to
their respective value. Using this we can detect the numbers of deaths
for the canton Lucerne.
It is backwords compatible. If there are no valid numbers found the
output of field `Deaths` is omitted.

Thanks to @baryluk who pointed me to the right files.

Closes openZH/covid_19#195