### PR TITLE
Use empty string instead of None for add_db_entry.py

### DIFF
--- a/scrapers/add_db_entry.py
+++ b/scrapers/add_db_entry.py
@@ -32,12 +32,12 @@ try:
             'date': date_part[0],
             'time': '',
             'area': os.environ['SCRAPER_KEY'],
-            'tested': None,
+            'tested': '',
             'confirmed': int(match.group(3)),
-            'hospitalized': None,
-            'icu': None,
-            'vent': None,
-            'released': None,
+            'hospitalized': '',
+            'icu': '',
+            'vent': '',
+            'released': '',
             'deceased': match.group(4),
             'source': os.environ['SCRAPER_SOURCE']
         }
@@ -46,7 +46,7 @@ try:
             data['time'] = date_part[1]
 
         if (data['deceased'] == '-'):
-            data['deceased'] = None
+            data['deceased'] = ''
         else:
             data['deceased'] = int(data['deceased'])
 


### PR DESCRIPTION
I've noticed there's usually two commits from the scraper:

- one adding the new data: https://github.com/openZH/covid_19/commit/8ed511b1617e5c9d6849f14b2830362d4e9c5897
- a second one adding quotes for empty fields: https://github.com/openZH/covid_19/commit/613737e06c7292ec7c7bc229c6f81e9e9e179886

It looks like when the existing data is loaded from CSV, an empty string is used instead of `null`/`None`. So lets always use an empty string.