### PR TITLE
Disable web.archive.org snapshoting by default.

### DIFF
--- a/scrapers/meta_scrape.sh
+++ b/scrapers/meta_scrape.sh
@@ -24,8 +24,6 @@
 #
 # Number of deaths can be omitted, if not available.
 
-export WEBARCHIVE_SNAPSHOT=1
-
 for s in ./scrape_*.sh;
 do
   L=$(./$s | ./parse_scrape_output.py)


### PR DESCRIPTION
The env variable should be set manually outside of the script instead.
(This is already done on https://www.functor.xyz/covid_19/)

This way one can run the `meta_scrape.sh` manually, and not wait forever
for the snapshot to finish. Helps accelerate testing.
