### PR TITLE
History BE

### DIFF
--- a/fallzahlen_kanton_total_csv/COVID19_Fallzahlen_Kanton_BE_total.csv
+++ b/fallzahlen_kanton_total_csv/COVID19_Fallzahlen_Kanton_BE_total.csv
@@ -1,4 +1,16 @@
 date,time,abbreviation_canton_and_fl,ncumul_tested,ncumul_conf,ncumul_hosp,ncumul_ICU,ncumul_vent,ncumul_released,ncumul_deceased,source
+2020-02-28,"",BE,"",1,"","","","","",https://www.be.ch/portal/de/index/mediencenter/medienmitteilungen/suche.archiv.meldungNeu.html/portal/de/meldungen/mm/2020/02/20200229_0936_corona.html
+2020-03-01,"",BE,"",2,"","","","","",https://www.be.ch/portal/de/index/mediencenter/medienmitteilungen/suche.meldungNeu.html/portal/de/meldungen/mm/2020/03/20200302_1522_zweiter_bestaetigtercorona-fallinbiel
+2020-03-02,"",BE,"",4,"","","","","",https://www.be.ch/portal/de/index/mediencenter/medienmitteilungen/suche.meldungNeu.html/portal/de/meldungen/mm/2020/03/20200303_1333_mann_in_spital_interlakenpositivgetestet
+2020-03-04,"",BE,"",6,"","","","","",https://www.be.ch/portal/de/index/mediencenter/medienmitteilungen/suche.meldungNeu.html/portal/de/meldungen/mm/2020/03/20200304_1443_corona-4-3-2020
+2020-03-06,"",BE,"",17,"","","","","",https://www.be.ch/portal/de/index/mediencenter/medienmitteilungen/suche.meldungNeu.html/portal/de/meldungen/mm/2020/03/20200306_1343_corona6-3
+2020-03-08,"",BE,"",31,"","","","","",Berner Zeitung Infos BAG
+2020-03-09,"",BE,"",34,"","","","","",https://www.be.ch/portal/de/index/mediencenter/medienmitteilungen/suche.meldungNeu.html/portal/de/meldungen/mm/2020/03/20200309_1545_corona-9-3
+2020-03-10,"",BE,"",39,"","","","","",Der Bund Infos BAG
+2020-03-11,"",BE,"",41,"","","","","",Berner Zeitung Infos BAG
+2020-03-12,"",BE,"",51,"","","","","",Berner Zeitung Infos BAG
+2020-03-13,"",BE,"",67,"","","","","",Der Bund
+2020-03-14,"",BE,"",78,"","","","","",Der Bund Infos BAG
 2020-03-16,"",BE,"",123,"","","","",1,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 2020-03-18,"",BE,"",193,"","","","",1,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 2020-03-19,"",BE,"",282,"","","","",1,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html

--- a/fallzahlen_kanton_total_csv/COVID19_Fallzahlen_Kanton_BE_total.csv
+++ b/fallzahlen_kanton_total_csv/COVID19_Fallzahlen_Kanton_BE_total.csv
@@ -4,13 +4,7 @@ date,time,abbreviation_canton_and_fl,ncumul_tested,ncumul_conf,ncumul_hosp,ncumu
 2020-03-02,"",BE,"",4,"","","","","",https://www.be.ch/portal/de/index/mediencenter/medienmitteilungen/suche.meldungNeu.html/portal/de/meldungen/mm/2020/03/20200303_1333_mann_in_spital_interlakenpositivgetestet
 2020-03-04,"",BE,"",6,"","","","","",https://www.be.ch/portal/de/index/mediencenter/medienmitteilungen/suche.meldungNeu.html/portal/de/meldungen/mm/2020/03/20200304_1443_corona-4-3-2020
 2020-03-06,"",BE,"",17,"","","","","",https://www.be.ch/portal/de/index/mediencenter/medienmitteilungen/suche.meldungNeu.html/portal/de/meldungen/mm/2020/03/20200306_1343_corona6-3
-2020-03-08,"",BE,"",31,"","","","","",Berner Zeitung Infos BAG
 2020-03-09,"",BE,"",34,"","","","","",https://www.be.ch/portal/de/index/mediencenter/medienmitteilungen/suche.meldungNeu.html/portal/de/meldungen/mm/2020/03/20200309_1545_corona-9-3
-2020-03-10,"",BE,"",39,"","","","","",Der Bund Infos BAG
-2020-03-11,"",BE,"",41,"","","","","",Berner Zeitung Infos BAG
-2020-03-12,"",BE,"",51,"","","","","",Berner Zeitung Infos BAG
-2020-03-13,"",BE,"",67,"","","","","",Der Bund
-2020-03-14,"",BE,"",78,"","","","","",Der Bund Infos BAG
 2020-03-16,"",BE,"",123,"","","","",1,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 2020-03-18,"",BE,"",193,"","","","",1,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 2020-03-19,"",BE,"",282,"","","","",1,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html


### PR DESCRIPTION
History aus Medienmitteilungen Kanton Bern und tagaktuellen Meldungen des BAG aus Berner Zeitung und Der Bund.

Sourcing Presseinfos:
Berner Zeitung 08. März 2020, 17:14
Doppelt so viele Fälle im Kanton Bern
Die Zahl der Infizierten hat sich im Kanton Bern übers Wochenende fast verdoppelt. Wie aus den Unterlagen des Bundesamts für Gesundheit vom Sonntagmorgen hervorgeht, sind bisher 31 Personen positiv getestet worden. Bei 5 davon steht die Bestätigung des Referenzlabors noch aus."

Der Bund 09. März 2020, 13:32
34 Fälle im Kanton Bern
Im Kanton Bern ist die Anzahl Patientinnen und Patienten, die positiv auf das Coronavirus getestet wurden, auf 34 gestiegen. 27 Erkrankte haben einen definitiven Entscheid. Bei den übrigen Fällen liegt ein erstes Resultat vor. Die Angaben stammen vom Bundesamt für Gesundheit, Stand Montagabend."

Der Bund 10. März 2020, 12:26
39 Fälle im Kanton Bern
Die Anzahl Ansteckungen nimmt weiter zu: Bestätigte Fälle gibt es im Kanton Bern aktuell 37, bei zwei Personen steht das zweite positive Testresultat noch aus, wie das Bundesamt für Gesundheit (BAG) mitteilt."

Berner Zeitung 12. März 2020, 13:29
51 Infizierte in Bern
Im Kanton Bern ist die Zahl der Infizierten seit gestern auf von 41 auf 51 gestiegen. Das zeigen die neuesten Zahlen des Bundesamts für Gesundheit. In zwei Fällen steht die Bestätigung des Referenzlabors noch aus."

Berner Zeitung 12. März 2020, 13:29
51 Infizierte in Bern
Im Kanton Bern ist die Zahl der Infizierten seit gestern auf von 41 auf 51 gestiegen. Das zeigen die neuesten Zahlen des Bundesamts für Gesundheit. In zwei Fällen steht die Bestätigung des Referenzlabors noch aus."

Der Bund 13. März 2020, 17:26
67 bestätigte Fälle
Seit dem Mittag gibt es fünf weitere Corona-Infizierte im Kanton Bern. Damit beläuft sich die Zahl auf 67. Drei Personen befinden sich in einem kritische Zustand. In 9 Fällen steht die Bestätigung des zweiten Tests noch aus."

Der Bund 14. März 2020, 12:23
78 bestätigte Fälle im Kanton Bern
Am Samstagmorgen (Stand 08:30 Uhr) waren im Kanton Bern 78 Personen bekannt, die positiv auf das Coronavirus getestet wurden. Davon ist bei 9 Personen die die Bestätigung nach einem ersten positiven Test noch ausstehend. Die Angaben stammen vom Bundesamt für Gesundheit (BAG)."