### PR TITLE
Update `ncumul_released` for ZG

### DIFF
--- a/fallzahlen_kanton_total_csv/COVID19_Fallzahlen_Kanton_ZG_total.csv
+++ b/fallzahlen_kanton_total_csv/COVID19_Fallzahlen_Kanton_ZG_total.csv
@@ -7,6 +7,6 @@ date,time,abbreviation_canton_and_fl,ncumul_tested,ncumul_conf,ncumul_hosp,ncumu
 2020-03-20,"",ZG,"",48,1,"","",5,"",https://www.zg.ch/behoerden/gesundheitsdirektion/direktionssekretariat/aktuell/coronavirus-ausreichende-testkapazitaeten-im-kanton-zug-vorhanden
 2020-03-23,08:00,ZG,"",62,"","","",10,"",https://www.zg.ch/behoerden/gesundheitsdirektion/amt-fuer-gesundheit/corona
 2020-03-24,08:00,ZG,"",72,"","","",12,"",https://www.zg.ch/behoerden/gesundheitsdirektion/amt-fuer-gesundheit/corona
-2020-03-25,08:00,ZG,"",80,"","","",18,"",https://www.zg.ch/behoerden/gesundheitsdirektion/amt-fuer-gesundheit/corona
+2020-03-25,08:00,ZG,"",80,"","","","","",https://www.zg.ch/behoerden/gesundheitsdirektion/amt-fuer-gesundheit/corona
 2020-03-26,08:00,ZG,"",87,"","","",15,"",https://www.zg.ch/behoerden/gesundheitsdirektion/amt-fuer-gesundheit/corona
 2020-03-27,18:00,ZG,"",101,"","","",18,1,https://www.zg.ch/behoerden/gesundheitsdirektion/amt-fuer-gesundheit/corona


### PR DESCRIPTION
The number of released is unclear on the 2020-03-25, I propose to remove the number. It is verified that in the 2020-03-26 ZG reported 15 as `ncumul_released`