### PR TITLE
Fix LU scraper

### DIFF
--- a/scrapers/scrape_lu.sh
+++ b/scrapers/scrape_lu.sh
@@ -8,13 +8,13 @@ sc.timestamp()
 
 # 2020-03-25
 """
-        <p class="teaser__text richtext"><p>Im Kanton Luzern gibt es 228 best&auml;tige F&auml;lle (Stand: 25. M&auml;rz 2020, 11:00 Uhr).&nbsp; Es gibt zwei Todesf&auml;lle im Zusammenhang dem Coronavirus zu beklagen. </p>
+        <p class="teaser__text richtext"><p>Im Kanton Luzern gibt es 228 best&auml;tigte F&auml;lle (Stand: 25. M&auml;rz 2020, 11:00 Uhr).&nbsp; Es gibt zwei Todesf&auml;lle im Zusammenhang dem Coronavirus zu beklagen. </p>
 """
 
 d = sc.filter(r'Im Kanton Luzern gibt es', d)
 
 print('Date and time:', sc.find(r'Stand: (.+)(Uhr)?\)', d))
-print('Confirmed cases:', sc.find('gibt es ([0-9]+) best(&auml;|ä)tige F(&auml;|ä)lle', d))
+print('Confirmed cases:', sc.find('gibt es ([0-9]+) best(&auml;|ä)tigte F(&auml;|ä)lle', d))
 
 deathsString = sc.find('Es gibt (.*) Todesf(&auml;|ä)lle', d)
 


### PR DESCRIPTION
Fixes #338 

```
./scrape_lu.sh                                                                                                                                                                                                                     (2020-03-31-fix-lu-scraper✱)
LU
Downloading: https://gesundheit.lu.ch/themen/Humanmedizin/Infektionskrankheiten/Coronavirus
Scraped at: 2020-03-31T13:50:15+02:00
Date and time: 31. M&auml;rz 2020, 11:00 Uhr
Confirmed cases: 375
Deaths: 7
```

Not sure about the `31. M&auml;rz 2020, 11:00 Uhr` part. Seems it was like this before already, is that correct?