### PR TITLE
Remove SCRAPER_SOURCE

### DIFF
--- a/.github/workflows/run_bs_scraper.yml
+++ b/.github/workflows/run_bs_scraper.yml
@@ -32,7 +32,6 @@ jobs:
     - name: Scrape new data
       env:
         SCRAPER_KEY: BS
-        SCRAPER_SOURCE: https://www.coronavirus.bs.ch/nm/2020-tagesbulletin-coronavirus-534-bestaetigte-faelle-im-kanton-basel-stadt-gd.html
       run: |
         ./scrapers/run_scraper.sh
         


### PR DESCRIPTION
By removing this env var, the scraper will put the actual download URL as source

Closes #321 