### PR TITLE
Fix BE scraper

### DIFF
--- a/scrapers/parse_scrape_output.py
+++ b/scrapers/parse_scrape_output.py
@@ -99,6 +99,15 @@ def parse_date(d):
     assert 2020 <= int(mo[3]) <= 2021
     assert 1 <= int(mo[2]) <= 12
     return f"{int(mo[3]):4d}-{int(mo[2]):02d}-{int(mo[1]):02d}T{int(mo[4]):02d}:{int(mo[5]):02d}"
+  mo = re.search(r'^(\d+)\.(\d+)\.(\d\d),? (\d\d?)[h:\.](\d\d) ?h', d)
+  if mo:
+    # 31.03.20, 08.00 h
+    assert 1 <= int(mo[1]) <= 31
+    assert 1 <= int(mo[2]) <= 12
+    assert 20 <= int(mo[3]) <= 21
+    assert 1 <= int(mo[4]) <= 23
+    assert 0 <= int(mo[5]) <= 59
+    return f"{2000 + int(mo[3]):4d}-{int(mo[2]):02d}-{int(mo[1]):02d}T{int(mo[4]):02d}:{int(mo[5]):02d}"
   mo = re.search(r'^(\d+)\.(\d+)\.(20\d\d)$', d)
   if mo:
     # 20.03.2020

--- a/scrapers/scrape_be.sh
+++ b/scrapers/scrape_be.sh
@@ -80,12 +80,32 @@ assert header, "Header not matched"
 </tbody>
 """
 
-r = re.search(r'<tbody>\s*<tr>\s*<td.*?>(\d{2}.\d{2}.\d{4})</td>\s*<td.*?>([0-9]+| *)</td>\s*<td.*?>([0-9]+| *)</td>\s*<td.*?>([0-9]+| *)</td>\s*<td.*?>([0-9]+| *)</td>\s*<td.*?>([0-9]+| *)</td>\s*<td.*?>([0-9]+| *)</td>', d, flags=re.I)
+# 2020-03-31
+"""
+        <tr>
+                <td headers="th_top_5147_1A"><strong>31.03.20</strong><br />
+08.00 h</td>
+                        <td headers="th_top_5147_2A">856</td>
+                        <td headers="th_top_5147_3A">111</td>
+                        <td headers="th_top_5147_4A">88</td>
+                        <td headers="th_top_5147_5A">23</td>
+                        <td headers="th_top_5147_6A">18</td>
+                        <td headers="th_top_5147_7A">16</td>
+                        </tr>
+"""
+
+
+d = d.replace('<strong>', '').replace('</strong>', '')
+
+r = re.search(r'<tr[^>]*>\s*<td.*?>(\d{2}.\d{2}.\d{2,4})\s*(?:<br */?>)\s*(\d+\.\d+ h)?</td>\s*<td.*?>([0-9]+| *)</td>\s*<td.*?>([0-9]+| *)</td>\s*<td.*?>([0-9]+| *)</td>\s*<td.*?>([0-9]+| *)</td>\s*<td.*?>([0-9]+| *)</td>\s*<td.*?>([0-9]+| *)</td>', d, flags=re.I)
 assert r, "Row missmatch"
 
-print("Date and time:", r[1])
-print("Confirmed cases:", r[2].strip())
-print("Deaths:", r[7].strip())
-print("Hospitalized:", r[3].strip())
-print("ICU:", r[5].strip())
-print("Vent:", r[6].strip())
+if r[2]:
+  print("Date and time:", r[1] + ', ' + r[2])
+else:
+  print("Date and time:", r[1])
+print("Confirmed cases:", r[3].strip())
+print("Deaths:", r[8].strip())
+print("Hospitalized:", r[4].strip())
+print("ICU:", r[6].strip())
+print("Vent:", r[7].strip())


### PR DESCRIPTION
Some extra tags and changes in row format today.

I think I will rework the scraper later to extract rows and columns explicitly, by doing splits on `<tr>` and `<td>.*?<td>`, similar to what we do in few other scrapers. This will reduce size of the regexp considerably.

But this works, so lets merge.

Closes: https://github.com/openZH/covid_19/issues/351