### PR TITLE
Fix BS scraper

### DIFF
--- a/scrapers/scrape_bs.sh
+++ b/scrapers/scrape_bs.sh
@@ -19,7 +19,9 @@ URL = URL.split('"')[1]
 d = sc.download(f'https://www.gd.bs.ch/{URL}')
 sc.timestamp()
 
-d = sc.filter(r'positive Fälle', d)
+d = d.replace('&auml;', 'ä')
+d = d.replace('&nbsp;', ' ')
+d = sc.filter(r'positive\s*Fälle', d)
 
 # 2020-03-25
 """
@@ -48,6 +50,17 @@ d = sc.filter(r'positive Fälle', d)
 <p>Im Kanton Basel-Stadt werden nebst den Tests der Kantonsbewohnerinnen und -bewohner auch Tests von Verdachtsf&auml;llen aus anderen Schweizer Kantonen und dem grenznahen Ausland durchgef&uuml;hrt. Bisher sind die Tests von 773 Personen positiv ausgefallen (inklusive der 466 Basler F&auml;lle).</p>
 """
 
+# 2020-04-01
+"""
+                    <div class="lead">
+                        <p>Das Gesundheitsdepartement Basel-Stadt meldet mit Stand Mittwoch, 1. April 2020, 10 Uhr, 691 positive Fälle von Personen mit Wohnsitz im Kanton Basel-Stadt und zwei weitere Todesfälle. Aufgrund einer Labornachmeldung muss die Zahl der positiven Fälle einmalig nach oben korrigiert werden.</p>
+                    </div>
+
+
+                    <div class="text">
+                    <p>Mit Stand Mittwoch, 1. April 2020, 10 Uhr, liegen insgesamt 691 positive F&auml;lle von Personen mit Wohnsitz im Kanton Basel-Stadt vor. 323 Personen der 691 positiv Getesteten und damit &uuml;ber 45 Prozent sind wieder genesen.</p>
+"""
+
 # Use non-greedy matching.
-print('Date and time:', sc.find(r'Stand [A-Za-z]*,? (.+?), insgesamt', d))
-print('Confirmed cases:', sc.find(r'insgesamt ([0-9]+) positive', d))
+print('Date and time:', sc.find(r'Stand\s*[A-Za-z]*,?\s*(.+?),\s*(?:liegen\s*)?insgesamt', d))
+print('Confirmed cases:', sc.find(r'(?:insgesamt\s*)?([0-9]+)\s*positive', d))


### PR DESCRIPTION
The main issue was `ä` did become `&auml;`, so the filter didn't match.
Canonicalize it back to  `ä`. Do same with `&nbsp;` just in case, because
we seen many failures in other scrapers do this.

When at it, add some extract '\s*' instead of spaces.

Closes: https://github.com/openZH/covid_19/issues/370