### PR TITLE
Fix BL scraper

### DIFF
--- a/scrapers/scrape_bl.sh
+++ b/scrapers/scrape_bl.sh
@@ -36,7 +36,7 @@ Datum, Bestätigte Fälle, Verstorbene
 # 2020-04-01
 """
 <pre id="data" style="display:none;">
-Datum, Bestätigte Fälle, Geheilte geschätzt, Verstorbene
+Datum, Bestätigte Fälle, Geheilte kalkuliert, Verstorbene
 28-02-2020,1,,
 29-02-2020,2,,
 ...
@@ -47,7 +47,7 @@ Datum, Bestätigte Fälle, Geheilte geschätzt, Verstorbene
 
 d = d.replace('\n', ' ')
 # Extract last line. Use non-greedy matching.
-d = sc.find(r'<pre id="data".*?> ?Datum, Bestätigte Fälle, Geheilte geschätzt, Verstorbene.*? ([^ ]+) ?</pre>', d)
+d = sc.find(r'<pre id="data".*?> ?Datum, Bestätigte Fälle, Geheilte kalkuliert, Verstorbene.*? ([^ ]+) ?</pre>', d)
 assert d, "Can't find a data table"
 
 c = d.split(',')


### PR DESCRIPTION
Fixes #389 

```
./scrape_bl.sh
BL
Downloading: https://www.baselland.ch/politik-und-behorden/direktionen/volkswirtschafts-und-gesundheitsdirektion/amt-fur-gesundheit/medizinische-dienste/kantonsarztlicher-dienst/aktuelles/covid-19-faelle-kanton-basel-landschaft
Downloading: https://www.statistik.bl.ch/files/sites/Grafiken/COVID19/20200402_COVID19_BL.htm
Scraped at: 2020-04-02T21:50:21+02:00
Date and time: 02.04.2020
Confirmed cases: 610
Deaths: 12
Recovered: 262
```

They changed the column "Geheilte geschätzt" to "Geheilte kalkuliert".