### PR TITLE
Update SH scraper, add extra numbers

### DIFF
--- a/scrapers/scrape_sh.sh
+++ b/scrapers/scrape_sh.sh
@@ -9,6 +9,7 @@ sc.timestamp()
 d = sc.filter('data_post_content', d)
 d = d.replace('\\n', '\n')
 d = d.replace('&nbsp;', ' ')
+d = d.replace('&auml;', 'ä')
 
 # 2020-03-25
 """
@@ -20,6 +21,20 @@ d = d.replace('&nbsp;', ' ')
         "data_post_content":""<p class=\"post_text\">Im Kanton Schaffhausen gibt es aktuell (Stand 29.03.2020, 08:00 Uhr) <strong>&nbsp;40 best&auml;tige&nbsp;Coronavirus-F&auml;lle</strong>.<
 """
 
+# 2020-04-03
+"""
+        "data_post_content":"<p class=\"post_text\">Im Kanton Schaffhausen gibt es aktuell (Stand 02.04.2020):&nbsp;<\/p>\n\n<p class=\"post_text\"><strong>Anzahl Infizierte F&auml;lle (kumuliert): 47<\/strong><\/p>\n\n<p class=\"post_text\"><strong>Anzahl Hospitalisationen Isolation (aktuell): 15<\/strong><\/p>\n\n<p class=\"post_text\"><strong>Anzahl Hospitalisationen Intensiv (aktuell): 3<\/strong><\/p>\n\n<p class=\"post_text\"><strong>Verstorbene (kummuliert): 1<\/strong><\/p>\n\n<p ....
+"""
+
 
 print('Date and time:', sc.find(r'\(Stand ([^\)]+)\)', d)) # sc.filter('Im Kanton Schaffhausen gibt.*', d)
-print('Confirmed cases:', sc.find(r'\b([0-9]+)\s*best(&auml;|ä)tige\s*(Coronavirus)?-?\s*F(&auml;|ä)lle', d))
+print('Confirmed cases:', sc.find(r'\b([0-9]+)\s*bestätige\s*(Coronavirus)?-?\s*Fälle', d) or sc.find(r'(?:Anzahl)?\s*Infizierte\s*Fälle\s*(?:\(kumuliert\))?:\s*([0-9]+)<', d))
+hospitalized = sc.find(r'(?:Anzahl)?\s*Hospitalisationen\s*Isolation\s*(?:\(aktuell\))?:\s*([0-9]+)<', d)
+if hospitalized:
+  print('Hospitalized:', hospitalized)
+icu = sc.find(r'(?:Anzahl)?\s*Hospitalisationen\s*Intensiv\s*(?:\(aktuell\))?:\s*([0-9]+)<', d)
+if icu:
+  print('ICU:', icu)
+deaths = sc.find(r'Verstorbene\s*(?:\(kummuliert\))?:\s*([0-9]+)<', d)
+if deaths:
+  print('Deaths:', deaths)


### PR DESCRIPTION
Fix SH scraper due to format change.

Extract hospitalized, ICU and deceased numbers.

Closes: https://github.com/openZH/covid_19/issues/402