### PR TITLE
Add hospitalized numbers extraction to SO scraper + minor regexp changes

### DIFF
--- a/scrapers/scrape_so.sh
+++ b/scrapers/scrape_so.sh
@@ -6,6 +6,7 @@ print('SO')
 d = sc.download("https://corona.so.ch/")
 sc.timestamp()
 d = sc.filter("Situation Kanton Solothurn.*Stand|Anzahl positiv getesteter Erkrankungsfälle|Verstorben:", d)
+d = d.replace('<strong>', '').replace('</strong>', '')
 
 # 2020-03-23
 """
@@ -15,7 +16,12 @@ d = sc.filter("Situation Kanton Solothurn.*Stand|Anzahl positiv getesteter Erkra
 """
  <p class="bodytext"><strong>Situation Kanton Solothurn (Stand 02.04.2020, 0:00 Uhr)</strong></p><ul><li>Anzahl positiv getesteter Erkrankungsfälle: 227 (+11 im Vergleich zum Vortag)</li> 	<li>Verstorbene Personen:<strong> </strong>3 (keine Veränderung im Vergleich zum Vortag)</li></ul><p class="bodytext"> </p></div></div>
 """
+# 2020-04-03
+"""
+<p class="bodytext"><strong>Situation Kanton Solothurn (Stand 03.04.2020, 0:00 Uhr)</strong></p><ul><li>Anzahl positiv getesteter Erkrankungsfälle: 237 (+10 im Vergleich zum Vortag)</li> 	<li>Im Kanton hospitalisierte Patientinnen und Patienten: 17 (+3 im Vergleich zum Vortag)</li> 	<li>Verstorbene Personen:<strong> </strong>3 (keine Veränderung im Vergleich zum Vortag)</li></ul><p class="bodytext"> </p></div></div>
+"""
 
 print("Date and time:", sc.find(r'\(Stand ([^\)]+)\)<', d))
-print("Confirmed cases:", sc.find(r'Anzahl positiv getesteter Erkrankungsfälle: ([0-9]+) ', d))
-print("Deaths:", sc.find('Verstorben(?:e Personen)?:(<strong> <\/strong>)?([0-9]+) ', d, group=2))
+print("Confirmed cases:", sc.find(r'Anzahl\s*positiv\s*getesteter\s*Erkrankungsfälle\s*:\s*([0-9]+)\b', d))
+print("Hospitalized:", sc.find(r'Im\s*Kanton\s*hospitalisierte\s*(?:Patientinnen und Patienten|[^:]*)\s*:\s*([0-9]+)\b', d))
+print("Deaths:", sc.find(r'Verstorben(?:e Personen)?\s*:\s*([0-9]+)\b', d))


### PR DESCRIPTION
Extract hospitalized numbers from the website published starting today.

Make all spaces into `\s*`

Remove `<strong>` and `</strong>` tags, prior to matching.

Made some parts optional.

Match at the word boundary at the end, not necassarly space.

Closes: https://github.com/openZH/covid_19/issues/391