### PR TITLE
Scrape extra PDF for VS to get hostpialized, ICU, intubated, recovered

### DIFF
--- a/scrapers/scrape_common.py
+++ b/scrapers/scrape_common.py
@@ -31,12 +31,15 @@ def download(url, encoding='utf-8'):
   downloader = os.path.join(os.path.dirname(__file__), 'download.sh')
   return subprocess.run([downloader, url], capture_output=True, check=True).stdout.decode(encoding)
 
-def pdfdownload(url, encoding='utf-8'):
+def pdfdownload(url, encoding='utf-8', raw=False):
   """Download a PDF and convert it to text"""
   print("Downloading:", url)
   downloader = os.path.join(os.path.dirname(__file__), 'download.sh')
   with subprocess.Popen([downloader, url], stdout=subprocess.PIPE) as pdf:
-    with subprocess.Popen(['pdftotext', '-', '-'], stdin=pdf.stdout, stdout=subprocess.PIPE) as text:
+    pdf_command = ['pdftotext', '-', '-']
+    if raw:
+      pdf_command = ['pdftotext', '-raw', '-', '-']
+    with subprocess.Popen(pdf_command, stdin=pdf.stdout, stdout=subprocess.PIPE) as text:
       t = text.stdout.read()
       text.wait()
       return t.decode(encoding)


### PR DESCRIPTION
Tested on all released PDFs since 2020-03-25.

Normalize matching of '&auml;' in existing code.

Use `pdftotext -raw` to a bit easier matching.

The matching using non-raw pdftotext might be more reliable, but actually
requires way way more code to get done correctly.

pdftotext -raw dumps characters in document stream order, instead of in
positional (top-bottom, left-right) order, and in this particular case
makes matching easier.

Closes: https://github.com/openZH/covid_19/issues/315