### PR TITLE
Scrape deceased numbers for GL. Improve existing regexps.

### DIFF
--- a/scrapers/scrape_gl.sh
+++ b/scrapers/scrape_gl.sh
@@ -5,8 +5,10 @@ import scrape_common as sc
 print('GL')
 d = sc.download('https://www.gl.ch/verwaltung/finanzen-und-gesundheit/gesundheit/coronavirus.html/4817')
 sc.timestamp()
+d = d.replace('&nbsp;', ' ')
+d = d.replace('&auml;', 'ä')
 
-d = sc.filter(r'Fallzahlen Kanton Glarus.+Update|Best(ä|&auml;)tigte F(ä|&auml;)lle|Wahrscheinliche F(ä|&auml;)lle|Hospitalisierungen', d)
+d = sc.filter(r'Fallzahlen\s*Kanton\s*Glarus.+Update|Bestätigte\s*Fälle|Wahrscheinliche\s*Fälle|Hospitalisierungen|Verstorbene', d)
 
 #      <li><strong><a href="#Fallzahlen">Fallzahlen Kanton Glarus</a> (Update 22.03.2020, 13.30 Uhr)</strong></li> 
 #...
@@ -22,6 +24,17 @@ d = sc.filter(r'Fallzahlen Kanton Glarus.+Update|Best(ä|&auml;)tigte F(ä|&auml
       <p>Die Zahl der bestätigten Fälle umfasst die seit Messbeginn erfassten Personen, die positiv auf COVID-19 getestet wurden. Bereits wieder genesene Personen sind in diesen Zahlen ebenfalls enthalten.</p> 
 """
 
-print('Date and time:', sc.find(r'Update (.+ Uhr)\)<', d))
-print('Confirmed cases:', sc.find(r'Bestätigte Fälle: <strong>([0-9]+)(&nbsp;)?<', sc.filter(r'Best(ä|&auml;)tigte F(ä|&auml;)lle', d)))
-print('Hospitalized:', sc.find(r'Hospitalisierungen: <strong>([0-9]+)(&nbsp;)?<', sc.filter(r'Hospitalisierungen', d)))
+# 2020-04-03
+# Note, that it misses numbers for hospitalized on this day / time.
+"""
+      <h2><strong><a id="Fallzahlen" name="Fallzahlen"></a>Coronavirus: Update Kanton Glarus</strong><br /> (Stand: 3.4.2020, 13:30 Uhr)</h2> 
+      <h2>Bestätigte Fälle: <strong>59&nbsp;</strong>(+1)&nbsp;<br /> Personen in Spitalpflege: <strong>5 </strong>(+/-0)&nbsp;<br /> Verstorbene Personen: <strong>2 </strong>(+/-0)</h2> 
+"""
+
+
+d = d.replace('<strong>', '').replace('</strong>', '')
+
+print('Date and time:', sc.find(r'Update\s*(.+ Uhr)\)<', d))
+print('Confirmed cases:', sc.find(r'Bestätigte\s*Fälle\s*:\s*([0-9]+)\b', d))
+print('Hospitalized:', sc.find(r'Hospitalisierungen\s*:\s*([0-9]+)\b', d))
+print('Deaths:', sc.find(r'Verstorbene\s*Personen\s*:\s*([0-9+])\b', d))


### PR DESCRIPTION
Extrace number of deceased in GL scraper.

Replace matching spaces with \s*

Normalize &auml;

Remove redundant filters before sc.find.

Simplify number capture. Do not assume trailing <, instead use \b for
match.

Simplify optional \<strong\> matching, by removing these tags instead
first.

Closes: https://github.com/openZH/covid_19/issues/416