### PR TITLE
Add a matrix of expectations for each scraper in the parser.

### DIFF
--- a/scrapers/parse_scrape_output.py
+++ b/scrapers/parse_scrape_output.py
@@ -198,6 +198,7 @@ def maybe_new_int(name, value, old_value, required=False):
             warns.append(f"{name} ({value}) not a number")
     return old_value
 
+import scrape_matrix as sm
 
 try:
     i = 0
@@ -278,6 +279,10 @@ try:
     urls = ", ".join(url_sources)
 
     if date and cases and not errs:
+        violated_expectations = sm.check_expected(abbr, deaths=deaths, hospitalized=hospitalized, icu=icu, vent=vent, released=recovered)
+        # For now just print warnings on stderr.
+        for violated_expectation in violated_expectations:
+          print(f'WARNING: {violated_expectation}', file=sys.stderr)
         print("{:2} {:<16} {:>7} {:>7} OK {}{}{}".format(
             abbr,
             date,

--- a/scrapers/scrape_matrix.py
+++ b/scrapers/scrape_matrix.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+
+import sys
+
+# This file contains expectations of what data is provided by each scraper.
+# It is used by the parser to verify no expected field is missing,
+# which would indicate broken parser, or change to a website.
+#
+# It is to track and detect regressions.
+
+# A per-canton list of extra fields that are expected to be present.
+# Number of confirmed cases is always required to be present,
+# and is not listed in this list.
+matrix = {
+  # Note: Please keep the order of cantons and entries.
+  'AG': ['Deaths', 'Hospitalized', 'ICU', 'Vent'],
+  'AI': [],
+  'AR': ['Deaths'],
+  'BE': ['Deaths', 'Hospitalized', 'ICU', 'Vent'],
+  'BL': ['Deaths', 'Released'],
+  # BS: Technically there are Deaths numbers on website, but we don't scrape
+  # them at the moment (2020-04-04).
+  # See https://github.com/openZH/covid_19/issues/193 for details.
+  'BS': ['Released', 'Hospitalized', 'ICU'],
+  'FR': ['Deaths', 'Hospitalized', 'ICU'],
+  'GE': ['Deaths', 'Hospitalized', 'ICU'],
+  'GL': ['Deaths', 'Hospitalized'],
+  'GR': ['Deaths', 'Hospitalized'],
+  'JU': ['Hospitalized', 'ICU'],
+  'LU': ['Deaths', 'Hospitalized', 'ICU'],
+  'NE': ['Deaths'],  # Currently broken.
+  'NW': ['Deaths'],  # Currently 0, but present.
+  'OW': [],
+  'SG': ['Deaths', 'Released', 'Hospitalized', 'ICU'],
+  'SH': ['Deaths', 'Hospitalized', 'ICU'],
+  'SO': ['Deaths', 'Hospitalized'],
+  'SZ': ['Deaths', 'Released'],
+  'TG': ['Deaths'],
+  'TI': ['Deaths', 'Released', 'Hospitalized', 'ICU', 'Vent'],
+  'UR': ['Deaths', 'Released', 'Hospitalized'],
+  'VD': ['Deaths', 'Hospitalized', 'ICU'],
+  'VS': ['Deaths', 'Released', 'Hospitalized', 'ICU', 'Vent'],
+  'ZG': ['Deaths', 'Released'],
+  'ZH': ['Deaths', 'Hospitalized', 'Vent'],
+  # 'FL': [],  # No scraper.
+}
+
+allowed_extras = ['Deaths', 'Released', 'Hospitalized', 'ICU', 'Vent']
+
+# List of cantons that are expecte to have date AND time.
+matrix_time = [
+  'AG',
+  'AI',
+  'AR',
+  'BE',
+  # 'BL',  # Not available.
+  'BS',
+  # 'FR',  # Not available.
+  'GE',
+  'GL',
+  # 'GR',  # Not available.
+  'JU',
+  'LU',
+  'NW',
+  # 'NE',  # Broken scraper.
+  # 'OW',  # Not available.
+  # 'SG',  # Not available.
+  # 'SH',  # Not available.
+  'SO',
+  # 'SZ',  # Not available.
+  # 'TG',  # Not available.
+  'TI',
+  'UR',
+  # 'VD',  # Not available.
+  'VS',
+  'ZG',
+  'ZH',
+  # 'FL',  # No scraper.
+]
+
+def check_expected(abbr, deaths, hospitalized, icu, vent, released):
+  """
+  Verify that canton `abbr` has expected numbers presents.
+  If not, return a non-empty list of expectation violations back to the caller.
+  """
+  extras = matrix[abbr]
+
+  for k in extras:
+    if k not in allowed_extras:
+      print(f'WARNING: Unknown extra {k} present (typo?) in expectation matrix[{abbr}]', file=sys.stderr)
+
+  violated_expectations = []
+
+  cross = {
+    'Deaths': deaths,
+    'Hospitalized': hospitalized,
+    'ICU': icu,
+    'Vent': vent,
+    'Released': released,
+  }
+
+  # Check for fields that should be there, but aren't
+  for k, v in cross.items():
+    if v is None and k in extras:
+      violated_expectations.append(f'Expected {k} to be present for {abbr}')
+
+  # Check for new fields, that are there, but we didn't expect them
+  for k, v in cross.items():
+    if v is not None and k not in extras:
+      violated_expectations.append(f'Not expected {k} to be present for {abbr}. Update scrape_matrix.py file.')
+
+  return violated_expectations


### PR DESCRIPTION
This is an independent list that is checked against what scraper
provides. If any expected number is missing, it is reported as warning to
stderr.

In the future we might turn it into an error and fail parsing, to
indicate stronger that the scraper is broken or something.

This is related to https://github.com/openZH/covid_19/issues/68
and https://github.com/openZH/covid_19/issues/68#issuecomment-605527035
in particular.