### PR TITLE
Fix OW scraper. Add deceased and hospitalized.

### DIFF
--- a/scrapers/scrape_matrix.py
+++ b/scrapers/scrape_matrix.py
@@ -30,7 +30,7 @@ matrix = {
   'LU': ['Deaths', 'Hospitalized', 'ICU'],
   'NE': ['Deaths'],  # Currently broken.
   'NW': ['Deaths'],  # Currently 0, but present.
-  'OW': [],
+  'OW': ['Deaths', 'Hospitalized'],
   'SG': ['Deaths', 'Released', 'Hospitalized', 'ICU'],
   'SH': ['Deaths', 'Hospitalized', 'ICU'],
   'SO': ['Deaths', 'Hospitalized'],
@@ -63,7 +63,7 @@ matrix_time = [
   'LU',
   'NW',
   # 'NE',  # Broken scraper.
-  # 'OW',  # Not available.
+  'OW',
   # 'SG',  # Not available.
   # 'SH',  # Not available.
   'SO',

--- a/scrapers/scrape_ow.py
+++ b/scrapers/scrape_ow.py
@@ -6,7 +6,6 @@ print('OW')
 d = sc.download('https://www.ow.ch/de/verwaltung/dienstleistungen/?dienst_id=5962', encoding='windows-1252')
 sc.timestamp()
 d = d.replace('&nbsp;', ' ')
-d = sc.filter(r'>Stand |ist bei [0-9]+ *Personen', d)
 
 # 2020-03-23
 """
@@ -28,5 +27,23 @@ d = sc.filter(r'>Stand |ist bei [0-9]+ *Personen', d)
 <p class="icmsPContent">Bisher ist bei 37&nbsp;Personen im Kanton Obwalden das Coronavirus nachgewiesen worden. Bereits genesene Personen sind in dieser Zahl ebenfalls enthalten&nbsp;(Stand: 27. M<E4>rz 2020).</p>
 """
 
-print('Date and time:', sc.find(r'Stand ([^<]+)<', d))
-print('Confirmed cases:', sc.find(r'ist bei ([0-9]+) *Personen', d))
+# 2020-04-06
+"""
+<h3 class="icmsH3Content"><strong><a id="Fallzahl" name="Fallzahl"></a>Fallzahl Kanton Obwalden (Stand 6. April 2020, 15.00 Uhr)</strong></h3>
+
+<ul>
+	<li>Positiv getestete Personen: 60</li>
+	<li>In Obwalden hospitalisierte Personen: 1</li>
+	<li>Verstorbene Personen: 0</li>
+</ul>
+"""
+
+
+print('Date and time:', sc.find(r'Stand ([^<]+ Uhr)', d) or
+                        sc.find(r'Stand ([^<]+)<', d))
+print('Confirmed cases:', sc.find(r'ist\s*bei\s*([0-9]+)\s*Personen', d) or
+                          sc.find(r'Positiv\s*getestete\s*Personen:?\s*([0-9]+)\b', d))
+
+# Reported from 2020-04-06
+print('Hospitalized:', sc.find(r'hospitalisierte\s*Personen:?\s*([0-9]+)\b', d))
+print('Deaths:', sc.find(r'Verstorbene\s*Personen:?\s*([0-9]+)\b', d))


### PR DESCRIPTION
New page format. Easy fix.

The time of day is also now provided.

When at it, adjust existing regexp slightly, just in case.

This also adds deceased and hospitalized.

```
$ ./scrape_ow.py 
OW
Downloading: https://www.ow.ch/de/verwaltung/dienstleistungen/?dienst_id=5962
Scraped at: 2020-04-06T16:53:42+02:00
Date and time: 6. April 2020, 15.00 Uhr
Confirmed cases: 60
Hospitalized: 1
Deaths: 0

$ ./scrape_ow.py | ./parse_scrape_output.py 
OW 2020-04-06T15:00      60       0 OK 2020-04-06T16:55:20+02:00 # Extras: ncumul_hosp=1 # URLs: https://www.ow.ch/de/verwaltung/dienstleistungen/?dienst_id=5962
$
```