### PR TITLE
Fix NW scraper. Data in table. Add hospitalized and ICU.

### DIFF
--- a/scrapers/scrape_matrix.py
+++ b/scrapers/scrape_matrix.py
@@ -29,7 +29,7 @@ matrix = {
   'JU': ['Hospitalized', 'ICU'],
   'LU': ['Deaths', 'Hospitalized', 'ICU'],
   'NE': ['Deaths'],  # Currently broken.
-  'NW': ['Deaths'],  # Currently 0, but present.
+  'NW': ['Deaths', 'Hospitalized', 'ICU'],
   'OW': ['Deaths', 'Hospitalized'],
   'SG': ['Deaths', 'Released', 'Hospitalized', 'ICU'],
   'SH': ['Deaths', 'Hospitalized', 'ICU'],

--- a/scrapers/scrape_nw.py
+++ b/scrapers/scrape_nw.py
@@ -43,10 +43,56 @@ d = d.replace('<strong>', ' ').replace('</strong>', ' ')
 Verstorbene Personen:&nbsp;<strong>0</strong></p>
 """
 
+# 2020-04-06
+"""
+<p class="icmsPContent icms-wysiwyg-first"><em>Stand: 6.&nbsp;April 2020, 15.15 Uhr</em></p>
+...
+...
+...
+...
+<strong>Anzahl Fälle</strong></h3>
+
+<table cellpadding="1" cellspacing="1" class="icms-wysiwyg-table-zebra" icms="LIST" style="width:540px">
+	<tbody>
+		<tr>
+			<td class="icmscell0" icms="0" style="width:349px">COVID-19</td>
+			<td class="icmscell0" icms="0" style="text-align:center; width:100px">Anzahl</td>
+			<td class="icmscell0" icms="0" style="text-align:center; width:87px">Veränderung</td>
+		</tr>
+		<tr>
+			<td class="icmscell1" icms="1" style="width:349px">Positiv getestete Personen</td>
+			<td class="icmscell1" icms="1" style="text-align:center; width:100px">86</td>
+			<td class="icmscell1" icms="1" style="text-align:center; width:87px">+6</td>
+		</tr>
+		<tr>
+			<td class="icmscell2" icms="2" style="text-align:left; width:349px">Derzeit hospitalisiert</td>
+			<td class="icmscell2" icms="2" style="text-align:center; width:100px">9</td>
+			<td class="icmscell2" icms="2" style="text-align:center; width:87px">&nbsp;</td>
+		</tr>
+		<tr>
+			<td class="icmscell1" icms="1" style="text-align:left; width:349px">Davon auf der Intensivstation</td>
+			<td class="icmscell1" icms="1" style="text-align:center; width:100px">2</td>
+			<td class="icmscell1" icms="1" style="text-align:center; width:87px">&nbsp;</td>
+		</tr>
+		<tr>
+			<td class="icmscell2" icms="2" style="text-align:left; width:349px">Verstorbene Personen</td>
+			<td class="icmscell2" icms="2" style="text-align:center; width:100px">0</td>
+			<td class="icmscell2" icms="2" style="text-align:center; width:87px">&nbsp;</td>
+		</tr>
+	</tbody>
+</table>
+"""
+
 print('Date and time:', sc.find(r'em>Stand: *([^<]+)<\/em>', d))
 
-a = sc.find(r'Bisher (ist bei|sind) ([0-9]+)(&nbsp;| )Pers', d, group=2)
-b = sc.find(r'Positiv\s*getestete\s*Personen:\s*([0-9]+)\b', d)
-print('Confirmed cases:', a or b)
+a = sc.find(r'Bisher\s*(?:ist\s*bei|sind)\s*([0-9]+)(&nbsp;| )Pers', d)
+b = sc.find(r'Positiv\s*getestete\s*Personen:?\s*([0-9]+)\b', d)
+c = sc.find(r'Positiv\s*getestete\s*Personen</t[dh]>\s*<t[dh][^>]*>([0-9]+)\b', d)
+print('Confirmed cases:', a or b or c)
 
-print('Deaths:', sc.find(r'(?:Am\s*Virus\s*)?verstorbene\s*Persone?n?:\s*([0-9]+)\b', d))
+print('Deaths:', sc.find(r'(?:Am\s*Virus\s*)?verstorbene\s*Persone?n?:?\s*([0-9]+)\b', d) or
+                 sc.find(r'Verstorbene\s*Personen</t[dh]>\s*<t[dh][^>]*>([0-9]+)\b', d))
+
+# Added on 2020-04-06
+print('Hospitalized:', sc.find(r'Derzeit\s*hospitalisiert</t[dh]>\s*<t[dh][^>]*>([0-9]+)\b', d))
+print('ICU:', sc.find(r'Davon\s*auf\s*der\s*Intensiv\s*station</t[dh]>\s*<t[dh][^>]*>([0-9]+)\b', d))


### PR DESCRIPTION
Also relax very slightly existing regexps (space handling).

Closes: https://github.com/openZH/covid_19/issues/454

```
$ ./scrape_nw.py 
NW
Downloading: https://www.nw.ch/gesundheitsamtdienste/6044
Scraped at: 2020-04-06T18:04:00+02:00
Date and time: 6. April 2020, 15.15 Uhr
Confirmed cases: 86
Deaths: 0
Hospitalized: 9
ICU: 2
$ ./scrape_nw.py  | ./parse_scrape_output.py 
NW 2020-04-06T15:15      86       0 OK 2020-04-06T18:04:02+02:00 # Extras: ncumul_hosp=9,ncumul_ICU=2 # URLs: https://www.nw.ch/gesundheitsamtdienste/6044
$
```
