### PR TITLE
Fix a date regexp regression / break due to non-optional group

### DIFF
--- a/scrapers/parse_scrape_output.py
+++ b/scrapers/parse_scrape_output.py
@@ -92,13 +92,14 @@ def parse_date(d):
         assert 20 <= int(mo[3]) <= 21
         assert 1 <= int(mo[2]) <= 12
         return f"20{int(mo[3]):02d}-{int(mo[2]):02d}-{int(mo[1]):02d}T"
-    mo = re.search(r'^(\d+)\.(\d+)\.(20\d\d)[,:]? (\d\d?)[h:\.](\d\d)(?: Uhr)', d)
+    mo = re.search(r'^(\d+)\.(\d+)\.(20\d\d)[,:]? (\d\d?)[h:\.](\d\d)(?:h| Uhr)?', d)
     if mo:
         # 20.3.2020, 16.30
         # 21.03.2020, 15h30
         # 23.03.2020, 12:00
         # 23.03.2020 12:00
         # 08.04.2020: 09.30 Uhr
+        # 07.04.2020 15.00h
         assert 2020 <= int(mo[3]) <= 2021
         assert 1 <= int(mo[2]) <= 12
         return f"{int(mo[3]):4d}-{int(mo[2]):02d}-{int(mo[1]):02d}T{int(mo[4]):02d}:{int(mo[5]):02d}"


### PR DESCRIPTION
Bug introduced in https://github.com/openZH/covid_19/pull/478
made some cantons loose time of a day information, and one of them
actually fail to parse due to the suffix.

Sorry.