### PR TITLE
Add Recovered for scraper for AG

### DIFF
--- a/fallzahlen_kanton_total_csv/COVID19_Fallzahlen_Kanton_AG_total.csv
+++ b/fallzahlen_kanton_total_csv/COVID19_Fallzahlen_Kanton_AG_total.csv
@@ -27,5 +27,5 @@ date,time,abbreviation_canton_and_fl,ncumul_tested,ncumul_conf,ncumul_hosp,ncumu
 2020-04-02,15:00,AG,"",592,94,27,27,"",12,https://www.ag.ch/media/kanton_aargau/themen_1/coronavirus_1/lagebulletins/200402_KFS_Coronavirus_Lagebulletin_25.pdf
 2020-04-03,15:00,AG,"",626,100,27,26,"",12,https://www.ag.ch/media/kanton_aargau/themen_1/coronavirus_1/lagebulletins/200403_KFS_Coronavirus_Lagebulletin_26.pdf
 2020-04-06,15:00,AG,"",727,82,25,24,"",13,https://www.ag.ch/media/kanton_aargau/themen_1/coronavirus_1/lagebulletins/200406_KFS_Coronavirus_Lagebulletin_27.pdf
-2020-04-07,14:45,AG,"",760,84,25,25,"",16,https://www.ag.ch/media/kanton_aargau/themen_1/coronavirus_1/lagebulletins/200407_KFS_Coronavirus_Lagebulletin_28.pdf
-2020-04-08,14:45,AG,"",788,56,23,23,"",16,https://www.ag.ch/media/kanton_aargau/themen_1/coronavirus_1/lagebulletins/200408_KFS_Coronavirus_Lagebulletin_29.pdf
+2020-04-07,14:45,AG,"",760,84,25,25,170,16,https://www.ag.ch/media/kanton_aargau/themen_1/coronavirus_1/lagebulletins/200407_KFS_Coronavirus_Lagebulletin_28.pdf
+2020-04-08,14:45,AG,"",788,56,23,23,220,16,https://www.ag.ch/media/kanton_aargau/themen_1/coronavirus_1/lagebulletins/200408_KFS_Coronavirus_Lagebulletin_29.pdf

--- a/scrapers/scrape_ag.py
+++ b/scrapers/scrape_ag.py
@@ -16,6 +16,8 @@ print('Date and time:', sc.find(r'class="timeline__time" datetime="00(.*?00)"', 
 
 print('Confirmed cases:', sc.find(r'zurzeit ([0-9]+) best(ä|&auml;)tigte F(ä|&auml;)lle', d))
 
+print('Recovered:', sc.find(r'gelten im Aargau rund ([0-9]+) Personen .*? als geheilt', d))
+
 print('Hospitalized:', sc.find(r'([0-9]+) Person(en)? sind zurzeit hospitalisiert', d))
 
 print('ICU:', sc.find(r'([0-9]+) Person(en)?( werden)? auf Intensivstationen behandelt', d))

--- a/scrapers/scrape_matrix.py
+++ b/scrapers/scrape_matrix.py
@@ -13,7 +13,7 @@ import sys
 # and is not listed in this list.
 matrix = {
   # Note: Please keep the order of cantons and entries.
-  'AG': ['Deaths', 'Hospitalized', 'ICU', 'Vent'],
+  'AG': ['Deaths', 'Released', 'Hospitalized', 'ICU', 'Vent'],
   'AI': [],
   'AR': ['Deaths'],
   'BE': ['Deaths', 'Hospitalized', 'ICU', 'Vent'],


### PR DESCRIPTION
Looks like AG has decided to give at least an estimation of recovered again

They previously stopped on 19.03.2020: https://github.com/openZH/covid_19/pull/12