### PR TITLE
Parse xls as dict

### DIFF
--- a/scrapers/parse_scrape_output.py
+++ b/scrapers/parse_scrape_output.py
@@ -254,7 +254,11 @@ try:
                 abbr) == 2, f"The first line should be 2 letter abbreviation in upper case of the canton: Got: {l}"
             assert abbr.upper() == abbr, f"The first line should be 2 letter abbreviation in upper case of the canton: Got: {l}"
             continue
-        k, v = l.split(": ", 1)
+        try:
+            k, v = l.split(": ", 1)
+        except ValueError:
+            warns.append(f"Value missing on line '{l}'")
+            continue
 
         v = v.strip()
 

--- a/scrapers/scrape_common.py
+++ b/scrapers/scrape_common.py
@@ -40,8 +40,24 @@ def xlsdownload(url):
     xls = xlrd.open_workbook(file_contents=r.content)
     return xls
 
-def xldate_as_datetime(sheet, date):
-    return xlrd.xldate.xldate_as_datetime(date, sheet.book.datemode)
+def parse_xls(book, sheet_index=0, header_row=1):
+    rows = []
+    sheet = book.sheet_by_index(sheet_index)
+    headers = {c: sheet.cell_value(header_row, c) for c in range(sheet.ncols)} 
+    for r in range(sheet.nrows):
+        entry = {}
+        for c, h in headers.items():
+            cell_type = sheet.cell_type(r, c)
+            value = sheet.cell_value(r, c)
+            if cell_type == xlrd.XL_CELL_DATE:
+                entry[h] = xlrd.xldate.xldate_as_datetime(value, book.datemode)
+            elif represents_int(value):
+                entry[h] = int(value)
+            else:
+                entry[h] = value
+
+        rows.append(entry)
+    return rows
 
 def pdfdownload(url, encoding='utf-8', raw=False, layout=False):
     """Download a PDF and convert it to text"""

--- a/scrapers/scrape_gl.py
+++ b/scrapers/scrape_gl.py
@@ -17,8 +17,8 @@ xls = sc.xlsdownload(xls_url)
 sc.timestamp()
 
 rows = sc.parse_xls(xls)
-last_row = rows[-1]
-if last_row:
+if rows:
+    last_row = rows[-1]
     print('Date and time:', last_row['Datum'].date().isoformat(), last_row['Zeit'].time().isoformat())
     print('Confirmed cases:', last_row['Bestätigte Fälle (kumuliert)'])
     print('Hospitalized:', last_row['Personen in Spitalpflege'])

--- a/scrapers/scrape_gl.py
+++ b/scrapers/scrape_gl.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 
 import re
 from bs4 import BeautifulSoup
@@ -15,25 +16,10 @@ xls_url = box.find('a', string=re.compile(r'.*Dokument.*')).get('href')
 xls = sc.xlsdownload(xls_url)
 sc.timestamp()
 
-sheet = xls.sheet_by_index(0)
-last_row = sheet.nrows - 1
-
-date_value = sheet.cell_value(last_row, 0)
-time_value = sheet.cell_value(last_row, 1)
-import xlrd
-current_date = sc.xldate_as_datetime(sheet, date_value)
-if time_value:
-  print('Date and time:', current_date.date().isoformat(), xlrd.xldate.xldate_as_datetime(time_value, xls.datemode).time().isoformat())
-else:
-  print('Date and time:', current_date.date().isoformat())
-
-cases = int(sheet.cell_value(last_row, 2))
-print('Confirmed cases:', cases)
-
-hosp = int(sheet.cell_value(last_row, 3))
-if hosp:
-    print('Hospitalized:', hosp)
-
-deaths = int(sheet.cell_value(last_row, 4))
-if deaths:
-    print('Deaths:', deaths)
+rows = sc.parse_xls(xls)
+last_row = rows[-1]
+if last_row:
+    print('Date and time:', last_row['Datum'].date().isoformat(), last_row['Zeit'].time().isoformat())
+    print('Confirmed cases:', last_row['Bestätigte Fälle (kumuliert)'])
+    print('Hospitalized:', last_row['Personen in Spitalpflege'])
+    print('Deaths:', last_row['Todesfälle (kumuliert)'])

--- a/scrapers/scrape_sz.py
+++ b/scrapers/scrape_sz.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 
 import re
 from bs4 import BeautifulSoup
@@ -12,20 +13,10 @@ xls_url = soup.find('a', string=re.compile(r'Coronaf.lle\s*im\s*Kanton\s*Schwyz'
 xls = sc.xlsdownload(xls_url)
 sc.timestamp()
 
-sheet = xls.sheet_by_index(0)
-last_row = sheet.nrows - 1
-
-date_value = sheet.cell_value(last_row, 0)
-current_date = sc.xldate_as_datetime(sheet, date_value)
-print('Date and time:', current_date.date().isoformat())
-
-cases = int(sheet.cell_value(last_row, 1)) 
-print('Confirmed cases:', cases)
-
-deaths = int(sheet.cell_value(last_row, 2))
-if deaths:
-    print('Deaths:', deaths)
-
-recovered = int(sheet.cell_value(last_row, 3))
-if recovered:
-    print('Recovered:', recovered)
+rows = sc.parse_xls(xls)
+last_row = rows[-1]
+if last_row:
+    print('Date and time:', last_row['Datum'].date().isoformat())
+    print('Confirmed cases:', last_row['Bestätigte Fälle (kumuliert)'])
+    print('Deaths:', last_row['Todesfälle (kumuliert)'])
+    print('Recovered:', last_row['Genesene (kumuliert)'])

--- a/scrapers/scrape_sz.py
+++ b/scrapers/scrape_sz.py
@@ -14,8 +14,8 @@ xls = sc.xlsdownload(xls_url)
 sc.timestamp()
 
 rows = sc.parse_xls(xls)
-last_row = rows[-1]
-if last_row:
+if rows:
+    last_row = rows[-1]
     print('Date and time:', last_row['Datum'].date().isoformat())
     print('Confirmed cases:', last_row['Bestätigte Fälle (kumuliert)'])
     print('Deaths:', last_row['Todesfälle (kumuliert)'])


### PR DESCRIPTION
the parse_xls method aims to provide a similar functionality than the
DictReader of the built-in csv module. As long as we have a header row
and all the data below, we can build a list of dicts. This makes the
parsing prone to errors like new columns being added or the order of the
columns is changed.