### PR TITLE
Make sure the script fails, if the pipeline fails

### DIFF
--- a/scrapers/run_scraper.sh
+++ b/scrapers/run_scraper.sh
@@ -3,6 +3,7 @@
 # Script to run a single scraper
 
 set -e
+set -o pipefail
 
 function cleanup {
   exit $?


### PR DESCRIPTION
This is a handy bash-option to actually fail if any command in the pipeline failed. I noticed that some scraper runs didn't fail properly, even though there were errors in the output.