### PR TITLE
Omit URL parameter for PDF source

### DIFF
--- a/scrapers/scrape_fl.py
+++ b/scrapers/scrape_fl.py
@@ -7,7 +7,7 @@ import re
 # get latest from list with all press releases
 d = sc.download('https://www.regierung.li/coronavirus', silent=True)
 
-pdf_url = sc.find(r'<a.*?href="([^"]+\.pdf[^"]*)".*?>.+Situationsbericht.+<\/a>', d)
+pdf_url = sc.find(r'<a.*?href="([^"]+\.pdf)[^"]*".*?>.+Situationsbericht.+<\/a>', d)
 assert pdf_url, "PDF URL not found"
 
 # download latest PDF


### PR DESCRIPTION
FL adds a timestamp paramater (`ts`) to all uploads, this is done to
avoid delivering a cached version of the file (i.e. the browser is
forced to always download the latest file).
For the scraper this leads to the situation, that the source URL changed
with every scraper run, so that the File is always updated. This leads
to a lot of unneccessary commits.

This change omits all URL parameters, since they are not needed to get
the file.