### PR TITLE
GE: only use date part of parsed week number

### DIFF
--- a/scrapers/scrape_ge.py
+++ b/scrapers/scrape_ge.py
@@ -63,7 +63,7 @@ if not pdf_url.startswith('http'):
 pdf = sc.pdfdownload(pdf_url, silent=True)
 
 week_number = sc.find(r'Situation semaine (\d+)', pdf)
-week_end_date = datetime.datetime.strptime('2020-W' + week_number + '-7', '%G-W%V-%u')
+week_end_date = datetime.datetime.strptime('2020-W' + week_number + '-7', '%G-W%V-%u').date()
 number_of_tests = sc.find(r'N total tests : (\d+\'\d+)', pdf)
 number_of_tests = number_of_tests.replace('\'', '')
 


### PR DESCRIPTION
entries for 2020-07-12 and 2020-07-12 were added with 00:00 times, which doesn't really make any sense. Shoud I remove the times in the PR as well?