### PR TITLE
Use utf-8 as default encoding

### DIFF
--- a/scrapers/scrape_common.py
+++ b/scrapers/scrape_common.py
@@ -133,7 +133,7 @@ def add_cert_to_bundle():
         with open(cafile, 'ab') as outfile:
             outfile.write(customca)
 
-def download(url, encoding=None, silent=False):
+def download(url, encoding='utf-8', silent=False):
     if not silent:
         print("Downloading:", url)
     headers = {'user-agent': 'Mozilla Firefox Mozilla/5.0; openZH covid_19 at github'}


### PR DESCRIPTION
if the encoding is not specified, requests will make a guess. This guess
    is not always what we want. So in order the replicate the "old"
    behavior of download.sh, we will always use utf-8 as encoding unless
    explicitly stateted otherwise. By passing `None` to the encoding
    parameter, one can fall-back to the guessing mechanism of the
    requests library.