### PR TITLE
VS: get isolated and quarantined from weekly report

### DIFF
--- a/.github/workflows/run_scrapers.yml
+++ b/.github/workflows/run_scrapers.yml
@@ -60,7 +60,7 @@ jobs:
         pip install -r requirements.txt
         sudo apt update || true # do not fail if update does not work
         sudo apt-get install sqlite3
-        if [ "$SCRAPER_KEY" = "FL" ] || [ "$SCRAPER_KEY" = "GE" ] || [ "$SCRAPER_KEY" = "VD" ] ; then
+        if [ "$SCRAPER_KEY" = "FL" ] || [ "$SCRAPER_KEY" = "GE" ] || [ "$SCRAPER_KEY" = "VD" ] || [ "$SCRAPER_KEY" = "VS" ] ; then
           sudo apt-get install poppler-utils
         fi
 

--- a/scrapers/scrape_vs.py
+++ b/scrapers/scrape_vs.py
@@ -13,7 +13,8 @@ content = sc.download(stat_url, silent=True)
 soup = BeautifulSoup(content, 'html.parser')
 res = soup.find(string=re.compile(r'Synthese COVID19 VS Woche\d+')).find_previous('a')
 weekly_pdf_url = base_url + res.attrs['href']
-content = sc.pdfdownload(weekly_pdf_url.replace(' ', '%20'), silent=True)
+weekly_pdf_url = weekly_pdf_url.replace(' ', '%20')
+content = sc.pdfdownload(weekly_pdf_url, silent=True)
 
 
 # add isolated/quarantined to the existing DayData item

--- a/scrapers/scrape_vs.py
+++ b/scrapers/scrape_vs.py
@@ -2,13 +2,15 @@
 # -*- coding: utf-8 -*-
 
 import datetime
+import re
+from bs4 import BeautifulSoup
 import scrape_common as sc
 
 xls_url = 'https://raw.githubusercontent.com/statistikZH/covid19_drop/master/Chiffres%20%20COVID-19%20Valais.xlsx'
 main_url = 'https://www.vs.ch/de/web/coronavirus'
 xls = sc.xlsdownload(xls_url, silent=True)
 rows = sc.parse_xls(xls, header_row=1)
-is_first = True
+data = []
 for i, row in enumerate(rows):
     if not isinstance(row['Date'], datetime.datetime):
         continue
@@ -16,10 +18,6 @@ for i, row in enumerate(rows):
         continue
     if row['Nb nouveaux cas positifs'] is None and row["Nb nouvelles admissions à l'hôpital"] is None:
         continue
-
-    if not is_first:
-        print('-' * 10)
-    is_first = False
 
     dd = sc.DayData(canton='VS', url=main_url)
     dd.datetime = row['Date'].date().isoformat()
@@ -31,5 +29,30 @@ for i, row in enumerate(rows):
     dd.deaths = row['Cumul décès COVID-19']
     if row['Nb de nouvelles sorties'] is not None:
         dd.recovered = sum(r['Nb de nouvelles sorties'] for r in rows[:i+1])
-    print(dd)
+    data.append(dd)
 
+# parse weekly data for isolated and quarantined numbers
+base_url = 'https://www.vs.ch'
+stat_url = base_url + '/de/web/coronavirus/statistiques'
+content = sc.download(stat_url, silent=True)
+soup = BeautifulSoup(content, 'html.parser')
+res = soup.find(string=re.compile(r'Synthese COVID19 VS Woche\d+')).find_previous('a')
+weekly_pdf_url = base_url + res.attrs['href']
+content = sc.pdfdownload(weekly_pdf_url.replace(' ', '%20'), silent=True)
+
+# add isolated/quarantined to the existing DayData item
+week_end_date = sc.find(r'vom (\d+)\. bis (\d+\.\d+\.20\d{2})', content, group=2)
+week_end_date = sc.date_from_text(week_end_date).isoformat()
+for dd in data:
+    if dd.datetime == week_end_date:
+        dd.isolated = sc.find(r'befanden\ssich\s(\d+)\spositive\sF.lle\snoch\simmer\sin\sIsolation', content)
+        dd.quarantined = sc.find(r'Isolation\sund\s(\d+)\sKontakte\sin\sQuarant.ne', content)
+        dd.quarantine_riskareatravel = sc.find(r'\s(\d+)\sReisende\sin\sQuarant.ne', content)
+
+# and print all items
+is_first = True
+for dd in data:
+    if not is_first:
+        print('-' * 10)
+    is_first = False
+    print(dd)

--- a/scrapers/scrape_vs.py
+++ b/scrapers/scrape_vs.py
@@ -6,11 +6,31 @@ import re
 from bs4 import BeautifulSoup
 import scrape_common as sc
 
+# parse weekly data for isolated and quarantined numbers
+base_url = 'https://www.vs.ch'
+stat_url = base_url + '/de/web/coronavirus/statistiques'
+content = sc.download(stat_url, silent=True)
+soup = BeautifulSoup(content, 'html.parser')
+res = soup.find(string=re.compile(r'Synthese COVID19 VS Woche\d+')).find_previous('a')
+weekly_pdf_url = base_url + res.attrs['href']
+content = sc.pdfdownload(weekly_pdf_url.replace(' ', '%20'), silent=True)
+
+
+# add isolated/quarantined to the existing DayData item
+week_end_date = sc.find(r'vom (\d+)\. bis (\d+\.\d+\.20\d{2})', content, group=2)
+week_end_date = sc.date_from_text(week_end_date).isoformat()
+
+dd = sc.DayData(canton='VS', url=weekly_pdf_url)
+dd.datetime = week_end_date
+dd.isolated = sc.find(r'befanden\ssich\s(\d+)\spositive\sF.lle\snoch\simmer\sin\sIsolation', content)
+dd.quarantined = sc.find(r'Isolation\sund\s(\d+)\sKontakte\sin\sQuarant.ne', content)
+dd.quarantine_riskareatravel = sc.find(r'\s(\d+)\sReisende\sin\sQuarant.ne', content)
+print(dd)
+
 xls_url = 'https://raw.githubusercontent.com/statistikZH/covid19_drop/master/Chiffres%20%20COVID-19%20Valais.xlsx'
 main_url = 'https://www.vs.ch/de/web/coronavirus'
 xls = sc.xlsdownload(xls_url, silent=True)
 rows = sc.parse_xls(xls, header_row=1)
-data = []
 for i, row in enumerate(rows):
     if not isinstance(row['Date'], datetime.datetime):
         continue
@@ -29,30 +49,6 @@ for i, row in enumerate(rows):
     dd.deaths = row['Cumul décès COVID-19']
     if row['Nb de nouvelles sorties'] is not None:
         dd.recovered = sum(r['Nb de nouvelles sorties'] for r in rows[:i+1])
-    data.append(dd)
 
-# parse weekly data for isolated and quarantined numbers
-base_url = 'https://www.vs.ch'
-stat_url = base_url + '/de/web/coronavirus/statistiques'
-content = sc.download(stat_url, silent=True)
-soup = BeautifulSoup(content, 'html.parser')
-res = soup.find(string=re.compile(r'Synthese COVID19 VS Woche\d+')).find_previous('a')
-weekly_pdf_url = base_url + res.attrs['href']
-content = sc.pdfdownload(weekly_pdf_url.replace(' ', '%20'), silent=True)
-
-# add isolated/quarantined to the existing DayData item
-week_end_date = sc.find(r'vom (\d+)\. bis (\d+\.\d+\.20\d{2})', content, group=2)
-week_end_date = sc.date_from_text(week_end_date).isoformat()
-for dd in data:
-    if dd.datetime == week_end_date:
-        dd.isolated = sc.find(r'befanden\ssich\s(\d+)\spositive\sF.lle\snoch\simmer\sin\sIsolation', content)
-        dd.quarantined = sc.find(r'Isolation\sund\s(\d+)\sKontakte\sin\sQuarant.ne', content)
-        dd.quarantine_riskareatravel = sc.find(r'\s(\d+)\sReisende\sin\sQuarant.ne', content)
-
-# and print all items
-is_first = True
-for dd in data:
-    if not is_first:
-        print('-' * 10)
-    is_first = False
+    print('-' * 10)
     print(dd)


### PR DESCRIPTION
See #1024 - this "version" should address the failing test run.

As stated in the other PR, there would be more data available in the previous weekly reports. This could be scraped as well, but I have the feeling that it would be a bit overkill to do this every 20mins - maybe a daily job could be introduced for it? :thinking: 