### PR TITLE
use the date instead of the week number for SG district scraper

### DIFF
--- a/scrapers/scrape_sg_districts.py
+++ b/scrapers/scrape_sg_districts.py
@@ -34,12 +34,12 @@ d = "\n".join(d.split("\n")[5:])
 
 reader = csv.DictReader(StringIO(d), delimiter=';')
 for row in reader:
-    week = sc.find(r'W(\d+)', row['Kalenderwoche'])
+    date = row['Falldatum']
 
     for key, value in inhabitants.items():
         dd = sc.DistrictData(canton='SG', district=key)
         dd.url = url
-        dd.week = week
+        dd.date = date
         dd.district_id = district_ids[key]
         dd.new_cases = row['Wahlkreis ' + key]
         dd.total_cases = row['Wahlkreis ' + key + ' (kumuliert)']

--- a/scrapers/scrape_sg_districts.py
+++ b/scrapers/scrape_sg_districts.py
@@ -34,12 +34,15 @@ d = "\n".join(d.split("\n")[5:])
 
 reader = csv.DictReader(StringIO(d), delimiter=';')
 for row in reader:
-    date = row['Falldatum']
+    week = sc.find(r'W(\d+)', row['Kalenderwoche'])
+    date = sc.date_from_text(row['Falldatum'])
 
     for key, value in inhabitants.items():
         dd = sc.DistrictData(canton='SG', district=key)
         dd.url = url
-        dd.date = date
+        dd.week = week
+        dd.year = date.year
+        dd.date = date.isoformat()
         dd.district_id = district_ids[key]
         dd.new_cases = row['Wahlkreis ' + key]
         dd.total_cases = row['Wahlkreis ' + key + ' (kumuliert)']


### PR DESCRIPTION
The data is pretty unreasonable right now, which is due to the last week entry is used. Instead it's probably better to use the dates...
I guess all existing data should be removed after merging this one, to avoid week/date data mixup.

![sg_districts](https://user-images.githubusercontent.com/5264842/95129621-90577080-075b-11eb-9326-fd2d47dc07cf.png)
