### PR TITLE
fix BE district scraper for yet another "multi line" format

### DIFF
--- a/scrapers/scrape_be_districts.py
+++ b/scrapers/scrape_be_districts.py
@@ -84,6 +84,8 @@ for row in tbody.find_all('tr'):
     content = tds[2].text.strip()
     # fix Munchen-<br />\nbuchsee stuff
     content = re.sub(r'-\n(\w)', r'-\1', content)
+    # fix <br /> without - from above, but no number on the next line...
+    content = re.sub(r'\n([A-Z|a-z])', r' \1', content)
     for item in content.split('\n'):
         res = re.match(r'(\d+) (.*)', item)
         assert res is not None, f'Unexpected item {item} for number / city'


### PR DESCRIPTION
ensure that this works:
```
3 Kleinst-<br />
gemeinden im Verwaltungskreis<br />
Berner Jura<br />
1 unbekannt</td>
```