### PR TITLE
BE district scraper: improve city name matching logic

### DIFF
--- a/scrapers/scrape_be_districts.py
+++ b/scrapers/scrape_be_districts.py
@@ -26,6 +26,7 @@ def parse_kleinstgemeinde(item, dds):
     # handle kleinstgemeinde stuff
     district = sc.find(r'Kleinst.* im( Verwaltungskreis)? (.*)', item, group=2)
     if district is not None:
+        district = district.strip()
         if district == 'Berner Jura':
             district = 'Jura bernois'
         dds[district].new_cases += new_cases

--- a/scrapers/scrape_be_districts.py
+++ b/scrapers/scrape_be_districts.py
@@ -10,6 +10,8 @@ def fix_city(city):
     city = re.sub(r' b\.\s?B\.', ' bei Bern', city)
     city = re.sub(r' a\.\s?A\.', ' an der Aare', city)
     city = re.sub(r' i\.\s?E\.', ' im Emmental', city)
+    city = re.sub(r' i\.\s?S\.', ' im Simmental', city)
+    city = re.sub(r' b\. ', ' bei ', city)
 
     # and handle a few special cases
     cities = {

--- a/scrapers/scrape_be_districts.py
+++ b/scrapers/scrape_be_districts.py
@@ -13,6 +13,7 @@ def fix_city(city):
 
     # and handle a few special cases
     cities = {
+        'Muri-Gümligen': 'Muri bei Bern',
         'St-Imier': 'Saint-Imier',
         'Thörishaus': 'Köniz',
     }


### PR DESCRIPTION
- replace the known abbreviations to the proper name
- and keep only a subset of hard-coded city names that do not match the list