### PR TITLE
BE district scraper: Avoid output with no data available

### DIFF
--- a/fallzahlen_bezirke/fallzahlen_kanton_BE_bezirk.csv
+++ b/fallzahlen_bezirke/fallzahlen_kanton_BE_bezirk.csv
@@ -15,7 +15,6 @@ DistrictId,District,Canton,Date,Week,Year,Population,TotalConfCases,NewConfCases
 241,"Jura bernois",BE,2020-10-12,,,53721,,6,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 241,"Jura bernois",BE,2020-10-13,,,53721,,10,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 241,"Jura bernois",BE,2020-10-14,,,53721,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
-241,"Jura bernois",BE,2020-10-15,,,53721,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 242,Biel/Bienne,BE,2020-09-29,,,101313,,1,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 242,Biel/Bienne,BE,2020-09-30,,,101313,,7,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 242,Biel/Bienne,BE,2020-10-01,,,101313,,5,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
@@ -32,7 +31,6 @@ DistrictId,District,Canton,Date,Week,Year,Population,TotalConfCases,NewConfCases
 242,Biel/Bienne,BE,2020-10-12,,,101313,,2,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 242,Biel/Bienne,BE,2020-10-13,,,101313,,7,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 242,Biel/Bienne,BE,2020-10-14,,,101313,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
-242,Biel/Bienne,BE,2020-10-15,,,101313,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 243,Seeland,BE,2020-09-29,,,74467,,1,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 243,Seeland,BE,2020-09-30,,,74467,,5,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 243,Seeland,BE,2020-10-01,,,74467,,3,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
@@ -49,7 +47,6 @@ DistrictId,District,Canton,Date,Week,Year,Population,TotalConfCases,NewConfCases
 243,Seeland,BE,2020-10-12,,,74467,,3,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 243,Seeland,BE,2020-10-13,,,74467,,10,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 243,Seeland,BE,2020-10-14,,,74467,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
-243,Seeland,BE,2020-10-15,,,74467,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 244,Oberaargau,BE,2020-09-29,,,81759,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 244,Oberaargau,BE,2020-09-30,,,81759,,2,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 244,Oberaargau,BE,2020-10-01,,,81759,,7,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
@@ -66,7 +63,6 @@ DistrictId,District,Canton,Date,Week,Year,Population,TotalConfCases,NewConfCases
 244,Oberaargau,BE,2020-10-12,,,81759,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 244,Oberaargau,BE,2020-10-13,,,81759,,4,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 244,Oberaargau,BE,2020-10-14,,,81759,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
-244,Oberaargau,BE,2020-10-15,,,81759,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 245,Emmental,BE,2020-09-29,,,97218,,1,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 245,Emmental,BE,2020-09-30,,,97218,,1,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 245,Emmental,BE,2020-10-01,,,97218,,1,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
@@ -83,7 +79,6 @@ DistrictId,District,Canton,Date,Week,Year,Population,TotalConfCases,NewConfCases
 245,Emmental,BE,2020-10-12,,,97218,,2,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 245,Emmental,BE,2020-10-13,,,97218,,4,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 245,Emmental,BE,2020-10-14,,,97218,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
-245,Emmental,BE,2020-10-15,,,97218,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 246,Bern-Mittelland,BE,2020-09-29,,,414658,,9,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 246,Bern-Mittelland,BE,2020-09-30,,,414658,,22,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 246,Bern-Mittelland,BE,2020-10-01,,,414658,,13,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
@@ -100,7 +95,6 @@ DistrictId,District,Canton,Date,Week,Year,Population,TotalConfCases,NewConfCases
 246,Bern-Mittelland,BE,2020-10-12,,,414658,,30,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 246,Bern-Mittelland,BE,2020-10-13,,,414658,,60,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 246,Bern-Mittelland,BE,2020-10-14,,,414658,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
-246,Bern-Mittelland,BE,2020-10-15,,,414658,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 247,Thun,BE,2020-09-29,,,107491,,4,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 247,Thun,BE,2020-09-30,,,107491,,4,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 247,Thun,BE,2020-10-01,,,107491,,8,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
@@ -117,7 +111,6 @@ DistrictId,District,Canton,Date,Week,Year,Population,TotalConfCases,NewConfCases
 247,Thun,BE,2020-10-12,,,107491,,12,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 247,Thun,BE,2020-10-13,,,107491,,9,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 247,Thun,BE,2020-10-14,,,107491,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
-247,Thun,BE,2020-10-15,,,107491,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 248,Obersimmental-Saanen,BE,2020-09-29,,,16588,,1,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 248,Obersimmental-Saanen,BE,2020-09-30,,,16588,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 248,Obersimmental-Saanen,BE,2020-10-01,,,16588,,2,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
@@ -134,7 +127,6 @@ DistrictId,District,Canton,Date,Week,Year,Population,TotalConfCases,NewConfCases
 248,Obersimmental-Saanen,BE,2020-10-12,,,16588,,3,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 248,Obersimmental-Saanen,BE,2020-10-13,,,16588,,1,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 248,Obersimmental-Saanen,BE,2020-10-14,,,16588,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
-248,Obersimmental-Saanen,BE,2020-10-15,,,16588,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 249,Frutigen-Niedersimmental,BE,2020-09-29,,,40375,,2,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 249,Frutigen-Niedersimmental,BE,2020-09-30,,,40375,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 249,Frutigen-Niedersimmental,BE,2020-10-01,,,40375,,8,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
@@ -151,7 +143,6 @@ DistrictId,District,Canton,Date,Week,Year,Population,TotalConfCases,NewConfCases
 249,Frutigen-Niedersimmental,BE,2020-10-12,,,40375,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 249,Frutigen-Niedersimmental,BE,2020-10-13,,,40375,,4,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 249,Frutigen-Niedersimmental,BE,2020-10-14,,,40375,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
-249,Frutigen-Niedersimmental,BE,2020-10-15,,,40375,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 250,Interlaken-Oberhasli,BE,2020-09-29,,,47387,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 250,Interlaken-Oberhasli,BE,2020-09-30,,,47387,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 250,Interlaken-Oberhasli,BE,2020-10-01,,,47387,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
@@ -168,4 +159,3 @@ DistrictId,District,Canton,Date,Week,Year,Population,TotalConfCases,NewConfCases
 250,Interlaken-Oberhasli,BE,2020-10-12,,,47387,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 250,Interlaken-Oberhasli,BE,2020-10-13,,,47387,,6,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 250,Interlaken-Oberhasli,BE,2020-10-14,,,47387,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
-250,Interlaken-Oberhasli,BE,2020-10-15,,,47387,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html

--- a/fallzahlen_bezirke/fallzahlen_kanton_BE_bezirk.csv
+++ b/fallzahlen_bezirke/fallzahlen_kanton_BE_bezirk.csv
@@ -14,7 +14,6 @@ DistrictId,District,Canton,Date,Week,Year,Population,TotalConfCases,NewConfCases
 241,"Jura bernois",BE,2020-10-11,,,53721,,21,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 241,"Jura bernois",BE,2020-10-12,,,53721,,6,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 241,"Jura bernois",BE,2020-10-13,,,53721,,10,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
-241,"Jura bernois",BE,2020-10-14,,,53721,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 242,Biel/Bienne,BE,2020-09-29,,,101313,,1,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 242,Biel/Bienne,BE,2020-09-30,,,101313,,7,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 242,Biel/Bienne,BE,2020-10-01,,,101313,,5,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
@@ -30,7 +29,6 @@ DistrictId,District,Canton,Date,Week,Year,Population,TotalConfCases,NewConfCases
 242,Biel/Bienne,BE,2020-10-11,,,101313,,14,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 242,Biel/Bienne,BE,2020-10-12,,,101313,,2,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 242,Biel/Bienne,BE,2020-10-13,,,101313,,7,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
-242,Biel/Bienne,BE,2020-10-14,,,101313,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 243,Seeland,BE,2020-09-29,,,74467,,1,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 243,Seeland,BE,2020-09-30,,,74467,,5,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 243,Seeland,BE,2020-10-01,,,74467,,3,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
@@ -46,7 +44,6 @@ DistrictId,District,Canton,Date,Week,Year,Population,TotalConfCases,NewConfCases
 243,Seeland,BE,2020-10-11,,,74467,,5,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 243,Seeland,BE,2020-10-12,,,74467,,3,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 243,Seeland,BE,2020-10-13,,,74467,,10,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
-243,Seeland,BE,2020-10-14,,,74467,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 244,Oberaargau,BE,2020-09-29,,,81759,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 244,Oberaargau,BE,2020-09-30,,,81759,,2,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 244,Oberaargau,BE,2020-10-01,,,81759,,7,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
@@ -62,7 +59,6 @@ DistrictId,District,Canton,Date,Week,Year,Population,TotalConfCases,NewConfCases
 244,Oberaargau,BE,2020-10-11,,,81759,,7,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 244,Oberaargau,BE,2020-10-12,,,81759,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 244,Oberaargau,BE,2020-10-13,,,81759,,4,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
-244,Oberaargau,BE,2020-10-14,,,81759,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 245,Emmental,BE,2020-09-29,,,97218,,1,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 245,Emmental,BE,2020-09-30,,,97218,,1,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 245,Emmental,BE,2020-10-01,,,97218,,1,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
@@ -78,7 +74,6 @@ DistrictId,District,Canton,Date,Week,Year,Population,TotalConfCases,NewConfCases
 245,Emmental,BE,2020-10-11,,,97218,,5,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 245,Emmental,BE,2020-10-12,,,97218,,2,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 245,Emmental,BE,2020-10-13,,,97218,,4,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
-245,Emmental,BE,2020-10-14,,,97218,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 246,Bern-Mittelland,BE,2020-09-29,,,414658,,9,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 246,Bern-Mittelland,BE,2020-09-30,,,414658,,22,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 246,Bern-Mittelland,BE,2020-10-01,,,414658,,13,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
@@ -94,7 +89,6 @@ DistrictId,District,Canton,Date,Week,Year,Population,TotalConfCases,NewConfCases
 246,Bern-Mittelland,BE,2020-10-11,,,414658,,59,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 246,Bern-Mittelland,BE,2020-10-12,,,414658,,30,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 246,Bern-Mittelland,BE,2020-10-13,,,414658,,60,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
-246,Bern-Mittelland,BE,2020-10-14,,,414658,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 247,Thun,BE,2020-09-29,,,107491,,4,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 247,Thun,BE,2020-09-30,,,107491,,4,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 247,Thun,BE,2020-10-01,,,107491,,8,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
@@ -110,7 +104,6 @@ DistrictId,District,Canton,Date,Week,Year,Population,TotalConfCases,NewConfCases
 247,Thun,BE,2020-10-11,,,107491,,5,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 247,Thun,BE,2020-10-12,,,107491,,12,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 247,Thun,BE,2020-10-13,,,107491,,9,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
-247,Thun,BE,2020-10-14,,,107491,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 248,Obersimmental-Saanen,BE,2020-09-29,,,16588,,1,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 248,Obersimmental-Saanen,BE,2020-09-30,,,16588,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 248,Obersimmental-Saanen,BE,2020-10-01,,,16588,,2,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
@@ -126,7 +119,6 @@ DistrictId,District,Canton,Date,Week,Year,Population,TotalConfCases,NewConfCases
 248,Obersimmental-Saanen,BE,2020-10-11,,,16588,,4,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 248,Obersimmental-Saanen,BE,2020-10-12,,,16588,,3,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 248,Obersimmental-Saanen,BE,2020-10-13,,,16588,,1,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
-248,Obersimmental-Saanen,BE,2020-10-14,,,16588,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 249,Frutigen-Niedersimmental,BE,2020-09-29,,,40375,,2,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 249,Frutigen-Niedersimmental,BE,2020-09-30,,,40375,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 249,Frutigen-Niedersimmental,BE,2020-10-01,,,40375,,8,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
@@ -142,7 +134,6 @@ DistrictId,District,Canton,Date,Week,Year,Population,TotalConfCases,NewConfCases
 249,Frutigen-Niedersimmental,BE,2020-10-11,,,40375,,3,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 249,Frutigen-Niedersimmental,BE,2020-10-12,,,40375,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 249,Frutigen-Niedersimmental,BE,2020-10-13,,,40375,,4,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
-249,Frutigen-Niedersimmental,BE,2020-10-14,,,40375,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 250,Interlaken-Oberhasli,BE,2020-09-29,,,47387,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 250,Interlaken-Oberhasli,BE,2020-09-30,,,47387,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 250,Interlaken-Oberhasli,BE,2020-10-01,,,47387,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
@@ -158,4 +149,3 @@ DistrictId,District,Canton,Date,Week,Year,Population,TotalConfCases,NewConfCases
 250,Interlaken-Oberhasli,BE,2020-10-11,,,47387,,3,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 250,Interlaken-Oberhasli,BE,2020-10-12,,,47387,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
 250,Interlaken-Oberhasli,BE,2020-10-13,,,47387,,6,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html
-250,Interlaken-Oberhasli,BE,2020-10-14,,,47387,,0,,,https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html

--- a/scrapers/scrape_be_districts.py
+++ b/scrapers/scrape_be_districts.py
@@ -108,10 +108,11 @@ for row in tbody.find_all('tr'):
     content = re.sub(r'-\n(\w)', r'-\1', content)
     # fix <br /> without - from above, but no number on the next line...
     content = re.sub(r'\n([A-Z|a-z])', r' \1', content)
-    for item in content.split('\n'):
-        if item.lower() == 'Aufgrund der hohen Anzahl Fälle werden keine Ortschaften genannt.'.lower():
-            continue
 
+    if content.lower() == 'Aufgrund der hohen Anzahl Fälle werden keine Ortschaften genannt.'.lower():
+        continue
+
+    for item in content.split('\n'):
         res = re.match(r'(\d+) (.*)', item)
         assert res is not None, f'Unexpected item {item} for number / city'
         new_cases = int(res[1])


### PR DESCRIPTION
is it fine like that? or would it make more sense to output the entries, but with empty `NewConfCases` value?
I'm not fully sure, what is more reasonable...

resolves #1180