### PR TITLE
AG: Remove no longer published data from scraping

### DIFF
--- a/scrapers/scrape_ag.py
+++ b/scrapers/scrape_ag.py
@@ -16,22 +16,6 @@ if not xls_url.startswith('http'):
 xls = sc.xlsdownload(xls_url, silent=True)
 is_first = True
 
-# quarantine_riskareatravel
-rows = sc.parse_xls(xls, sheet_name='5. Quarantäne nach Einreise', header_row=2)
-for row in rows:
-    if not isinstance(row['A'], datetime.datetime):
-        continue
-
-
-    dd = sc.DayData(canton='AG', url=xls_url)
-    dd.datetime = f"{row['A'].date().isoformat()} {row['A'].time().isoformat()}"
-    dd.quarantine_riskareatravel = row['Gesamtzahl aktuell betreuter Personen']
-    if dd:
-        if not is_first:
-            print('-' * 10)
-        is_first = False
-        print(dd)
-
 # quarantine + isolation
 rows = sc.parse_xls(xls, sheet_name='2. Contact Tracing', header_row=2)
 for row in rows:


### PR DESCRIPTION
The information about risk-area-travelers is not published in the excel source anymore. Scraper will fail because the sheet is missing.