### PR TITLE
add scrapers for performed tests

### DIFF
--- a/scrapers/scrape_ag.py
+++ b/scrapers/scrape_ag.py
@@ -1,18 +1,11 @@
 #!/usr/bin/env python3
 
-from bs4 import BeautifulSoup
-import re
 import datetime
 import scrape_common as sc
+import scrape_ag_common as sac
 
 
-data_url = 'https://www.ag.ch/de/themen_1/coronavirus_2/lagebulletins/lagebulletins_1.jsp'
-d = sc.download(data_url, silent=True)
-soup = BeautifulSoup(d, 'html.parser')
-xls_url = soup.find('a', href=re.compile(r'\.xlsx$'))['href']
-if not xls_url.startswith('http'):
-    xls_url = f'https://www.ag.ch{xls_url}'
-    
+xls_url = sac.get_ag_xls_url()
 xls = sc.xlsdownload(xls_url, silent=True)
 is_first = True
 

--- a/scrapers/scrape_ag_common.py
+++ b/scrapers/scrape_ag_common.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+from bs4 import BeautifulSoup
+import re
+import scrape_common as sc
+
+
+def get_ag_xls_url():
+    data_url = 'https://www.ag.ch/de/themen_1/coronavirus_2/lagebulletins/lagebulletins_1.jsp'
+    d = sc.download(data_url, silent=True)
+    soup = BeautifulSoup(d, 'html.parser')
+    xls_url = soup.find('a', href=re.compile(r'\.xlsx$'))['href']
+    if not xls_url.startswith('http'):
+        xls_url = f'https://www.ag.ch{xls_url}'
+    return xls_url

--- a/scrapers/scrape_ag_tests.py
+++ b/scrapers/scrape_ag_tests.py
@@ -7,7 +7,7 @@ import scrape_ag_common as sac
 xls_url = sac.get_ag_xls_url()
 xls = sc.xlsdownload(xls_url, silent=True)
 
-rows = sc.parse_xls(xls, sheet_name='1.3 Tests', header_row=1, support_float=True)
+rows = sc.parse_xls(xls, sheet_name='1.3 Tests', header_row=1)
 for row in rows:
     td = sc.TestData(canton='AG', url=xls_url)
     td.week = int(row['Kalenderwoche'])

--- a/scrapers/scrape_ag_tests.py
+++ b/scrapers/scrape_ag_tests.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+import scrape_common as sc
+import scrape_ag_common as sac
+
+
+xls_url = sac.get_ag_xls_url()
+xls = sc.xlsdownload(xls_url, silent=True)
+
+rows = sc.parse_xls(xls, sheet_name='1.3 Tests', header_row=1, support_float=True)
+for row in rows:
+    td = sc.TestData(canton='AG', url=xls_url)
+    td.week = int(row['Kalenderwoche'])
+    td.year = '2020'
+    td.positive_tests = int(row['Positive Tests'])
+    td.negative_tests = int(row['Negative Tests'])
+    td.positivity_rate = float(row['Positivitätsrate'])
+    if td:
+        print(td)

--- a/scrapers/scrape_ag_tests.py
+++ b/scrapers/scrape_ag_tests.py
@@ -7,7 +7,7 @@ import scrape_ag_common as sac
 xls_url = sac.get_ag_xls_url()
 xls = sc.xlsdownload(xls_url, silent=True)
 
-rows = sc.parse_xls(xls, sheet_name='1.3 Tests', header_row=1)
+rows = sc.parse_xls(xls, sheet_name='1.3 Tests', header_row=1, enable_float=True)
 for row in rows:
     td = sc.TestData(canton='AG', url=xls_url)
     td.week = int(row['Kalenderwoche'])

--- a/scrapers/scrape_be_tests.py
+++ b/scrapers/scrape_be_tests.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+from bs4 import BeautifulSoup
+import re
+import scrape_common as sc
+
+html_url = 'https://www.besondere-lage.sites.be.ch/besondere-lage_sites/de/index/corona/index.html'
+d = sc.download(html_url, silent=True)
+
+soup = BeautifulSoup(d, 'html.parser')
+for t in soup.find_all('table', summary=re.compile(r'.*die Zahl der durchgef.hrten Tests pro.*')):
+    headers = [" ".join(cell.stripped_strings) for cell in t.find('tr').find_all('th')]
+
+    for row in [r for r in t.find_all('tr') if r.find_all('td')]:
+        td = sc.TestData(canton='BE', url=html_url)
+        tot_tests = None
+
+        for col_num, cell in enumerate(row.find_all(['td'])):
+            value = " ".join(cell.stripped_strings)
+            if value:
+                value = re.sub(r'[^\d\.]', '', value)
+
+            if sc.find(r'^(Kalender.*)', headers[col_num]) is not None:
+                td.week = value
+                td.year = '2020'
+            elif sc.find(r'^(Durchge.*Tests)', headers[col_num]):
+                tot_tests = int(value)
+            elif sc.find(r'^(davon.*positiv)', headers[col_num]):
+                td.positive_tests = int(value)
+            elif sc.find(r'^(Positivit.ts.*)', headers[col_num]):
+                td.positivity_rate = value
+
+        if tot_tests:
+            td.negative_tests = tot_tests - td.positive_tests
+            print(td)

--- a/scrapers/scrape_bs_tests.py
+++ b/scrapers/scrape_bs_tests.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+import csv
+from io import StringIO
+import scrape_common as sc
+
+
+url = 'https://data.bs.ch/explore/dataset/100094/download/?format=csv&timezone=Europe/Berlin&lang=en&use_labels_for_header=true&csv_separator=%3B'
+data = sc.download(url, silent=True)
+
+reader = csv.DictReader(StringIO(data), delimiter=';')
+for row in reader:
+    td = sc.TestData(canton='BS', url=url)
+    td.start_date = row['Datum']
+    td.end_date = row['Datum']
+    td.positive_tests = int(row['Positive Tests'])
+    td.negative_tests = int(row['Negative Tests'])
+    td.positivity_rate = float(row['Anteil positive Tests in Prozent'])
+    # prettify output a bit
+    td.positivity_rate = round(10 * td.positivity_rate) / 10
+    if td:
+        print(td)

--- a/scrapers/scrape_common.py
+++ b/scrapers/scrape_common.py
@@ -345,7 +345,7 @@ def download_file(url, path):
         for chunk in r.iter_content(1024):
             f.write(chunk)
 
-def parse_xls(book, header_row=1, sheet_index=0, sheet_name=None, skip_rows=1, columns_to_parse=None):
+def parse_xls(book, header_row=1, sheet_index=0, sheet_name=None, skip_rows=1, columns_to_parse=None, enable_float=False):
     rows = []
     if sheet_name:
         sheet = book.sheet_by_name(sheet_name)
@@ -367,9 +367,9 @@ def parse_xls(book, header_row=1, sheet_index=0, sheet_name=None, skip_rows=1, c
                 entry[h] = xlrd.xldate.xldate_as_datetime(value, book.datemode)
             elif cell_type == xlrd.XL_CELL_EMPTY:
                 entry[h] = None
-            elif represents_int(value) and int(value) == value:
+            elif represents_int(value):
                 entry[h] = int(value)
-            elif represents_float(value):
+            elif enable_float and represents_float(value):
                 entry[h] = float(value)
             else:
                 entry[h] = value

--- a/scrapers/scrape_common.py
+++ b/scrapers/scrape_common.py
@@ -190,6 +190,76 @@ class DistrictData:
         return 'DistrictId,District,Canton,Date,Week,Year,Population,TotalConfCases,NewConfCases,TotalDeaths,NewDeaths,SourceUrl'
 
 
+class TestData:
+    __initialized = False
+    SEPARATOR = ','
+
+    def __init__(self, canton=None, url=None):
+        self.start_date = None
+        self.end_date = None
+        self.week = None
+        self.year = None
+        self.canton = canton
+        self.positive_tests = None
+        self.negative_tests = None
+        self.positivity_rate = None
+        self.url = url
+        self.__initialized = True
+
+    def __setattr__(self, key, value):
+        if self.__initialized and not hasattr(self, key):
+            raise TypeError(f'unknown key: {key}')
+        object.__setattr__(self, key, value)
+
+    def __str__(self):
+        res = []
+        res.append(self.canton)
+        res.append('' if self.start_date is None else str(self.start_date))
+        res.append('' if self.end_date is None else str(self.end_date))
+        res.append('' if self.week is None else str(self.week))
+        res.append('' if self.year is None else str(self.year))
+        res.append('' if self.positive_tests is None else str(self.positive_tests))
+        res.append('' if self.negative_tests is None else str(self.negative_tests))
+        res.append('' if self.positivity_rate is None else str(self.positivity_rate))
+        res.append(self.url)
+        return DistrictData.SEPARATOR.join(res)
+
+    def __bool__(self):
+        attributes = [
+            self.positive_tests,
+            self.negative_tests,
+            self.positivity_rate,
+        ]
+        return any(v is not None for v in attributes)
+
+    @staticmethod
+    def __get_int_item(item):
+        return int(item) if represents_int(item) else None
+
+    @staticmethod
+    def __get_float_item(item):
+        return float(item) if represents_float(item) else None
+
+    def parse(self, data):
+        items = data.split(DistrictData.SEPARATOR)
+        if len(items) == 9:
+            self.canton = items[0]
+            self.start_date = items[1]
+            self.end_date = items[2]
+            self.week = self.__get_int_item(items[3])
+            self.year = self.__get_int_item(items[4])
+            self.positive_tests = self.__get_int_item(items[5])
+            self.negative_tests = self.__get_int_item(items[6])
+            self.positivity_rate = self.__get_float_item(items[7])
+            self.url = items[8]
+            return True
+        return False
+
+    @staticmethod
+    def header():
+        return 'Kanton,Woche_von,Woche_bis,Kalenderwoche,Jahr,Anzahl_positiv,Anzahl_negativ,Anteil_positiv,Url'
+
+
 spelledOutNumbersMap = {
     'eins': 1,
     'einen': 1,

--- a/scrapers/scrape_common.py
+++ b/scrapers/scrape_common.py
@@ -275,7 +275,7 @@ def download_file(url, path):
         for chunk in r.iter_content(1024):
             f.write(chunk)
 
-def parse_xls(book, header_row=1, sheet_index=0, sheet_name=None, skip_rows=1, columns_to_parse=None):
+def parse_xls(book, header_row=1, sheet_index=0, sheet_name=None, skip_rows=1, columns_to_parse=None, support_float=False):
     rows = []
     if sheet_name:
         sheet = book.sheet_by_name(sheet_name)
@@ -297,6 +297,8 @@ def parse_xls(book, header_row=1, sheet_index=0, sheet_name=None, skip_rows=1, c
                 entry[h] = xlrd.xldate.xldate_as_datetime(value, book.datemode)
             elif cell_type == xlrd.XL_CELL_EMPTY:
                 entry[h] = None
+            elif support_float and represents_float(value):
+                entry[h] = float(value)
             elif represents_int(value):
                 entry[h] = int(value)
             else:

--- a/scrapers/scrape_common.py
+++ b/scrapers/scrape_common.py
@@ -345,7 +345,7 @@ def download_file(url, path):
         for chunk in r.iter_content(1024):
             f.write(chunk)
 
-def parse_xls(book, header_row=1, sheet_index=0, sheet_name=None, skip_rows=1, columns_to_parse=None, support_float=False):
+def parse_xls(book, header_row=1, sheet_index=0, sheet_name=None, skip_rows=1, columns_to_parse=None):
     rows = []
     if sheet_name:
         sheet = book.sheet_by_name(sheet_name)
@@ -367,10 +367,10 @@ def parse_xls(book, header_row=1, sheet_index=0, sheet_name=None, skip_rows=1, c
                 entry[h] = xlrd.xldate.xldate_as_datetime(value, book.datemode)
             elif cell_type == xlrd.XL_CELL_EMPTY:
                 entry[h] = None
-            elif support_float and represents_float(value):
-                entry[h] = float(value)
-            elif represents_int(value):
+            elif represents_int(value) and int(value) == value:
                 entry[h] = int(value)
+            elif represents_float(value):
+                entry[h] = float(value)
             else:
                 entry[h] = value
 

--- a/scrapers/scrape_common.py
+++ b/scrapers/scrape_common.py
@@ -362,6 +362,13 @@ def represents_int(s):
     except (ValueError, TypeError):
         return False
 
+def represents_float(s):
+    try:
+        float(s)
+        return True
+    except (ValueError, TypeError):
+        return False
+
 def safeint(s):
     if not s:
         return s

--- a/scrapers/scrape_common.py
+++ b/scrapers/scrape_common.py
@@ -222,7 +222,7 @@ class TestData:
         res.append('' if self.negative_tests is None else str(self.negative_tests))
         res.append('' if self.positivity_rate is None else str(self.positivity_rate))
         res.append(self.url)
-        return DistrictData.SEPARATOR.join(res)
+        return TestData.SEPARATOR.join(res)
 
     def __bool__(self):
         attributes = [
@@ -241,7 +241,7 @@ class TestData:
         return float(item) if represents_float(item) else None
 
     def parse(self, data):
-        items = data.split(DistrictData.SEPARATOR)
+        items = data.split(TestData.SEPARATOR)
         if len(items) == 9:
             self.canton = items[0]
             self.start_date = items[1]

--- a/scrapers/scrape_fr.py
+++ b/scrapers/scrape_fr.py
@@ -1,21 +1,12 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import re
 import datetime
 import sys
-from bs4 import BeautifulSoup
 import scrape_common as sc
+from scrape_fr_common import get_fr_xls
 
-d = sc.download('https://www.fr.ch/sante/covid-19/coronavirus-statistiques-evolution-de-la-situation-dans-le-canton', silent=True)
-
-soup = BeautifulSoup(d, 'html.parser')
-xls_url = soup.find(href=re.compile("\.xlsx$")).get('href')
-assert xls_url, "URL is empty"
-if not xls_url.startswith('http'):
-    xls_url = f'https://www.fr.ch{xls_url}'
-
-xls = sc.xlsdownload(xls_url, silent=True)
+xls_url, xls = get_fr_xls()
 rows = sc.parse_xls(xls, header_row=0)
 is_first = True
 

--- a/scrapers/scrape_fr_common.py
+++ b/scrapers/scrape_fr_common.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import re
+from bs4 import BeautifulSoup
+import scrape_common as sc
+
+
+def get_fr_xls():
+    d = sc.download('https://www.fr.ch/sante/covid-19/coronavirus-statistiques-evolution-de-la-situation-dans-le-canton', silent=True)
+
+    soup = BeautifulSoup(d, 'html.parser')
+    xls_url = soup.find(href=re.compile("\.xlsx$")).get('href')
+    assert xls_url, "URL is empty"
+    if not xls_url.startswith('http'):
+        xls_url = f'https://www.fr.ch{xls_url}'
+
+    xls = sc.xlsdownload(xls_url, silent=True)
+    return xls_url, xls

--- a/scrapers/scrape_fr_districts.py
+++ b/scrapers/scrape_fr_districts.py
@@ -4,6 +4,7 @@
 import re
 from bs4 import BeautifulSoup
 import scrape_common as sc
+from scrape_fr_common import get_fr_xls
 
 inhabitants = {
     'Broye': 32894,
@@ -72,12 +73,7 @@ for tr in table.tbody.find_all('tr'):
 
 
 # daily data from xls
-xls_url = soup.find(href=re.compile("\.xlsx$")).get('href')
-assert xls_url, "URL is empty"
-if not xls_url.startswith('http'):
-    xls_url = f'https://www.fr.ch{xls_url}'
-
-xls = sc.xlsdownload(xls_url, silent=True)
+xls_url, xls = get_fr_xls()
 rows = sc.parse_xls(xls, header_row=0)
 for row in rows:
     row_date = row.search(r'.*Date.*')

--- a/scrapers/scrape_fr_tests.py
+++ b/scrapers/scrape_fr_tests.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from bs4 import BeautifulSoup
+import json
+import scrape_common as sc
+
+url = 'https://www.fr.ch/sante/covid-19/coronavirus-statistiques-evolution-de-la-situation-dans-le-canton'
+d = sc.download(url, silent=True)
+
+soup = BeautifulSoup(d, 'html.parser')
+
+json_data = soup.find('script', type="application/json").string
+json_data = json.loads(json_data)
+easychart = json_data['easychart']
+content = easychart['338566-0-field_graphique_content']
+
+csv = content['csv']
+csv = json.loads(csv)
+
+config = content['config']
+config = json.loads(config)
+xaxis = config['xAxis']
+categories = xaxis[0]['categories']
+
+for (tot, pos), week in zip(csv[1:], categories):
+    tot = int(tot)
+    pos = int(pos)
+    td = sc.TestData(canton='FR', url=url)
+    td.week = week
+    td.year = '2020'
+    td.positive_tests = pos
+    td.negative_tests = tot - pos
+    td.positivity_rate = float(pos / tot) * 100
+    td.positivity_rate = round(10 * td.positivity_rate) / 10
+    print(td)

--- a/scrapers/scrape_fr_tests.py
+++ b/scrapers/scrape_fr_tests.py
@@ -6,14 +6,14 @@ import scrape_common as sc
 from scrape_fr_common import get_fr_xls
 
 xls_url, xls = get_fr_xls()
-rows = sc.parse_xls(xls, header_row=0, sheet_name='tests COVID19')
+rows = sc.parse_xls(xls, header_row=0, sheet_name='tests COVID19', enable_float=True)
 
 for row in rows:
     td = sc.TestData(canton='FR', url=xls_url)
     td.week = sc.find(r'S (\d+)', row['Semaine'])
     td.year = '2020'
-    tot = row['Total Testing Pop FR']
-    pos = row['Total POS Pop FR']
+    tot = int(row['Total Testing Pop FR'])
+    pos = int(row['Total POS Pop FR'])
     td.positive_tests = pos
     td.negative_tests = tot - pos
     td.positivity_rate = float(pos / tot) * 100

--- a/scrapers/scrape_fr_tests.py
+++ b/scrapers/scrape_fr_tests.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from bs4 import BeautifulSoup
 import scrape_common as sc
 from scrape_fr_common import get_fr_xls
 

--- a/scrapers/scrape_sg_tests.py
+++ b/scrapers/scrape_sg_tests.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+import csv
+from io import StringIO
+import scrape_common as sc
+
+
+url = 'https://www.sg.ch/ueber-den-kanton-st-gallen/statistik/covid-19/_jcr_content/Par/sgch_downloadlist_729873930/DownloadListPar/sgch_download.ocFile/KantonSG_C19-Tests_download.csv'
+data = sc.download(url, silent=True)
+
+# strip the "header" / description lines
+data = "\n".join(data.split("\n")[9:])
+
+reader = csv.DictReader(StringIO(data), delimiter=';')
+for row in reader:
+    td = sc.TestData(canton='SG', url=url)
+    td.start_date = row['Datum']
+    td.end_date = row['Datum']
+    td.positive_tests = int(row['Positiv'])
+    td.negative_tests = int(row['Negativ'])
+    td.positivity_rate = float(row['Positiv in % vom Total']) * 100
+    td.positivity_rate = round(10 * td.positivity_rate) / 10
+    if td:
+        print(td)

--- a/scrapers/test/test_test_data.py
+++ b/scrapers/test/test_test_data.py
@@ -1,0 +1,31 @@
+from scrapers.scrape_common import TestData
+
+def test_test_data():
+    dd = TestData()
+    dd.start_date = '1'
+    dd.end_date = '2'
+    dd.week = 3
+    dd.year = 4
+    dd.canton = '5'
+    dd.positive_tests = 6
+    dd.negative_tests = 7
+    dd.positivity_rate = 8
+    dd.url = '9'
+
+    string = str(dd)
+
+    dd_parsed = TestData()
+    assert dd_parsed.parse(string)
+    assert dd.start_date == dd_parsed.start_date
+    assert dd.end_date == dd_parsed.end_date
+    assert dd.week == dd_parsed.week
+    assert dd.year == dd_parsed.year
+    assert dd.canton == dd_parsed.canton
+    assert dd.positive_tests == dd_parsed.positive_tests
+    assert dd.negative_tests == dd_parsed.negative_tests
+    assert dd.positivity_rate == dd_parsed.positivity_rate
+    assert dd.url == dd_parsed.url
+
+
+if __name__ == "__main__":
+    test_test_data()


### PR DESCRIPTION
Still a bit work in progress, since it's not really wired up anywhere.

The csv is based on the `COVID19_Anteil_positiver_Test_pro_KW.csv` ZH file, with some additional columns. Is that fine or should it stick to the ZH ones?

Also added an AG common file to retrieve the xlsx url in one place only.
(I guess that might be something for the FR scrapers to do as well)