### PR TITLE
Add test data from KW44 for GL

### DIFF
--- a/fallzahlen_tests/fallzahlen_kanton_GL_tests.csv
+++ b/fallzahlen_tests/fallzahlen_kanton_GL_tests.csv
@@ -1,2 +1,3 @@
 canton,start_date,end_date,week,year,positive_tests,negative_tests,total_tests,positivity_rate,source
+GL,,,44,2020,,,589,26.5,https://www.gl.ch/public/upload/assets/31866/Sentinella%20Bericht%20KW44.pdf
 GL,,,45,2020,,,566,25.6,https://www.gl.ch/public/upload/assets/31992/Sentinella%20Bericht%20KW45.pdf


### PR DESCRIPTION
The PDF from KW44 is still available with the search function of the website. I hope it's fine to add this manually and not extend the scraper to get it from the search page (since only KW44 and KW45 PDFs seem to be available).