### PR TITLE
Disable AG district scraper

### DIFF
--- a/.github/workflows/run_district_scrapers.yml
+++ b/.github/workflows/run_district_scrapers.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         canton:
-          - AG
+          #- AG
           #- BE
           - BL
           - FR


### PR DESCRIPTION
Since the district image has been removed from https://www.ag.ch/de/themen_1/coronavirus_2/lagebulletins/lagebulletins_1.jsp, we cannot scrape the data.