### PR TITLE
SH: get the content ids from the main page for the PDFs

### DIFF
--- a/scrapers/scrape_sh_tests.py
+++ b/scrapers/scrape_sh_tests.py
@@ -3,15 +3,30 @@
 
 import datetime
 import re
+from bs4 import BeautifulSoup
 import scrape_common as sc
 import scrape_sh_common as shc
 
-# last week and current weeks PDFs
-urls = [
-    'https://sh.ch/CMS/content.jsp?contentid=6840226&language=DE&_=1605991453278',
-    'https://sh.ch/CMS/content.jsp?contentid=6894309&language=DE&_=1606572960487',
-]
-for url in urls:
+# extract content_id of main page
+url = 'https://sh.ch/CMS/Webseite/Kanton-Schaffhausen/Beh-rde/Verwaltung/Departement-des-Innern/Gesundheitsamt-3209198-DE.html'
+d = sc.download(url, silent=True)
+content_id = sc.find(r"var contentid = '(\d+)';", d)
+assert content_id
+
+# get main page contents with the content id
+url = f'https://sh.ch/CMS/content.jsp?contentid={content_id}&language=DE'
+d = sc.jsondownload(url, silent=True)
+
+# and extract the Lagebericht content ids
+soup = BeautifulSoup(d['data_post_content'], 'html.parser')
+links = soup.find_all('a', text=re.compile(r'Lagebericht'))
+content_ids = []
+for link in links:
+    content_ids.append(link.get('contentid'))
+
+# fetch the PDFs and parse
+for content_id in content_ids:
+    url = f'https://sh.ch/CMS/content.jsp?contentid={content_id}&language=DE'
     pdf_url = shc.get_sh_url_from_json(url)
     pdf = sc.download_content(pdf_url, silent=True)
 


### PR DESCRIPTION
since the content ids seem to be changing for the weekly Lagebericht documents.