### PR TITLE
pin xlrd version to 1.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 beautifulsoup4
 requests
 dateparser
-xlrd
+xlrd==1.2.0
 pytest
 pandas


### PR DESCRIPTION
this should fix the most recent failures... it looks like something behaves different with version 2.0