### PR TITLE
use main page and make output conditional for VD tests scraper

### DIFF
--- a/scrapers/scrape_vd_common.py
+++ b/scrapers/scrape_vd_common.py
@@ -11,10 +11,9 @@ def get_weekly_pdf_url():
 
 def get_all_weekly_pdf_urls():
     base_url = 'https://www.infosan.vd.ch'
-    url = f'{base_url}/resultat-de-la-recherche/search/covid/?tx_solr[sort]=changed_asc asc'
-    d = sc.download(url, silent=True)
+    d = sc.download(base_url, silent=True)
 
-    urls = re.findall(r"window.open\('(.*\.pdf)'", d)
+    urls = re.findall(r"window.open\('(.*_epidemio\.pdf)'", d)
     result = []
     for url in urls:
         if not url.startswith('http'):

--- a/scrapers/scrape_vd_tests.py
+++ b/scrapers/scrape_vd_tests.py
@@ -29,12 +29,13 @@ for pdf_url in pdf_urls:
     td.end_date = end_date
 
     res = re.search(r'une\s+moyenne\s+de\s+(\d+)\s+frottis\s+SARS-CoV(-)?2', pdf)
-    assert res, f'failed to extract total number of tests from {pdf_url}'
-    days = (end_date - start_date).days
-    td.total_tests = days * int(res[1])
+    if res:
+        days = (end_date - start_date).days
+        td.total_tests = days * int(res[1])
 
     res = re.search(r'dont\s+(\d+\.?\d?)%\s+étaient\s+positifs', pdf)
-    assert res, f'failed to extract positivity rate from {pdf_url}'
-    td.positivity_rate = res[1]
+    if res:
+        td.positivity_rate = res[1]
 
-    print(td)
+    if td:
+        print(td)


### PR DESCRIPTION
- use infosan.vd.ch to get the latest PDF reports, the search doesn't
  include the latest PDFs
- support PDFs without total tests and positivity rate, the PDF from
  2020-12-08 does not contain the values.

The addition from today was a bit unexpected regarding the date: 0a0e82aa91b9395ea1723093a6eba987e82e3685
As mentioned above, the following PR should fix the issue and scrape the latest three PDFs from the main page.