### PR TITLE
use numeric ordering for weeks for tests/district csv output

### DIFF
--- a/scrapers/run_district_scraper.sh
+++ b/scrapers/run_district_scraper.sh
@@ -30,5 +30,5 @@ $scrape_script | $DIR/add_district_db_entry.py
 
 # 3. Export the database as csv
 echo "Export database to CSV..."
-sqlite3 -header -csv $DIR/data.sqlite "select * from data order by DistrictId, District, Canton, Date, Week, Year asc;" > $DIR/../fallzahlen_bezirke/fallzahlen_kanton_${SCRAPER_KEY}_bezirk.csv
+sqlite3 -header -csv $DIR/data.sqlite "select * from data order by DistrictId, District, Canton, Date, Year, Week+0 asc;" > $DIR/../fallzahlen_bezirke/fallzahlen_kanton_${SCRAPER_KEY}_bezirk.csv
 sed -i 's/""//g' $DIR/../fallzahlen_bezirke/fallzahlen_kanton_${SCRAPER_KEY}_bezirk.csv

--- a/scrapers/run_tests_scraper.sh
+++ b/scrapers/run_tests_scraper.sh
@@ -35,5 +35,5 @@ $scrape_script | $DIR/add_tests_db_entry.py
 
 # 3. Export the database as csv
 echo "Export database to CSV..."
-sqlite3 -header -csv $DIR/data.sqlite "select * from data order by canton, start_date, end_date, year, week asc;" > $DIR/../fallzahlen_tests/fallzahlen_${area}_tests.csv
+sqlite3 -header -csv $DIR/data.sqlite "select * from data order by canton, start_date, end_date, year, week+0 asc;" > $DIR/../fallzahlen_tests/fallzahlen_${area}_tests.csv
 sed -i 's/""//g' $DIR/../fallzahlen_tests/fallzahlen_${area}_tests.csv


### PR DESCRIPTION
https://github.com/openZH/covid_19/commit/411e64b1705edb282f0f5f8874e28263eac16993 shows that the weeks are ordered as string instead of a numerical ordering. This should be fixed with the `+0` (to cast it to a number), when creating the csv from the sqlite db.