### PR TITLE
SO: search for "Total" element instead of assuming it at a certain position

### DIFF
--- a/scrapers/scrape_so_districts.py
+++ b/scrapers/scrape_so_districts.py
@@ -44,8 +44,8 @@ def strip_so_number(value):
 soup = BeautifulSoup(d, 'html.parser')
 for district, d_id in district_ids.items():
     table = soup.find(text=district).find_next('table')
-    trs = table.find_all('tr')
-    tds = trs[-1].find_all('td')
+    tr = table.find('strong', text='Total').find_parent('tr')
+    tds = tr.find_all('td')
     assert tds[0].text == 'Total', f'Expected "Total" row, got {tds[0].text}'
     dd = sc.DistrictData(canton='SO', district=district)
     dd.url = url


### PR DESCRIPTION
to make the scraping more reliable and not fail for the current state
having an empty `<tr>` element in the end of the table.