### PR TITLE
manually add JU tests data for W12 2021

### DIFF
--- a/fallzahlen_tests/fallzahlen_kanton_JU_tests.csv
+++ b/fallzahlen_tests/fallzahlen_kanton_JU_tests.csv
@@ -21,3 +21,4 @@ JU,,,8,2021,151,,969,13.0,https://www.jura.ch/Htdocs/Files/v/36986.pdf/Departeme
 JU,,,9,2021,154,,927,14.0,https://www.jura.ch/Htdocs/Files/v/37064.pdf/Departements/CHA/SIC/Carrousel/Coronavirus/Chiffres/rapport_hebdo_COVID_JU_sem9_2021.pdf,,,,,,,,
 JU,,,10,2021,80,,1099,7.0,https://www.jura.ch/Htdocs/Files/v/37125.pdf/Departements/CHA/SIC/Carrousel/Coronavirus/Chiffres/rapport_hebdo_COVID_JU_sem10_2021.pdf,,,,,,,,
 JU,,,11,2021,97,,1383,7.0,https://www.jura.ch/Htdocs/Files/v/37180.pdf/Departements/CHA/SIC/Carrousel/Coronavirus/Chiffres/rapport_hebdo_COVID_JU_sem11_2021.pdf,,,,,,,,
+JU,,,12,2021,104,,1715,6.0,https://www.jura.ch/Htdocs/Files/v/37241.pdf/Departements/CHA/SIC/Carrousel/Coronavirus/Chiffres/rapport-hebdomadaire.pdf,,,,,,,,


### PR DESCRIPTION
because the PDF with the tests data is an image and thus cannot be parsed (that's the reason, why the scraper is constantly failing at the moment).