### PR TITLE
update TG tests scraper to latest webpage

### DIFF
--- a/scrapers/scrape_tg_tests.py
+++ b/scrapers/scrape_tg_tests.py
@@ -6,9 +6,12 @@ import scrape_common as sc
 url = 'https://statistik.tg.ch/themen-und-daten/covid-19.html/10816'
 content = sc.download(url, silent=True)
 
-res = re.search(r".*categories: \[('KW.*)\],", content)
+res = re.search(r".*name: '2020',\s+categories: \[(.*)\]\s+}, {\s+name: '2021',\s+categories: \[(.*)\]", content)
 assert res, f'failed to extract weeks, got {res}'
-weeks = res[1].split(',')
+weeks_2020 = res[1].split(',')
+weeks_2021 = res[2].split(',')
+weeks = weeks_2020 + weeks_2021
+years = ['2020'] * len(weeks_2020) + ['2021'] * len(weeks_2021)
 
 res = re.search(r".*name: 'Anzahl negativer Tests.?',\s+color: '.*',\s+data: \[(.*)\],", content)
 assert res, f'failed to extract negative tests, got {res}'
@@ -24,12 +27,9 @@ positivity_rate = res[1].split(',')
 
 assert len(weeks) == len(negative_tests) == len(positive_tests) == len(positivity_rate), f'Expected same length for weeks {len(weeks)}, neg. tests {len(negative_tests)}, pos. tests {len(positive_tests)}, pos. rate {len(positivity_rate)}'
 
-year = '2020'
-for week, neg, pos, rate in zip(weeks, negative_tests, positive_tests, positivity_rate):
+for week, year, neg, pos, rate in zip(weeks, years, negative_tests, positive_tests, positivity_rate):
     td = sc.TestData(canton='TG', url=url)
     td.week = sc.find(r'KW (\d+)', week)
-    if int(td.week) == 1:
-        year = '2021'
     td.year = year
     td.positive_tests = int(pos)
     td.negative_tests = int(neg)


### PR DESCRIPTION
that contains 2020 and 2021 week data in separate arrays.
build up year from the two arrays instead of "guessing" it.