### PR TITLE
FR common: use ISO-8859-1 encoding for CSV document

### DIFF
--- a/scrapers/scrape_fr_common.py
+++ b/scrapers/scrape_fr_common.py
@@ -17,6 +17,6 @@ def get_fr_csv():
     if not csv_url.startswith('http'):
         csv_url = f'https://www.fr.ch{csv_url}'
 
-    csv = sc.download(csv_url, silent=True)
+    csv = sc.download(csv_url, silent=True, encoding='ISO-8859-1')
     csv = re.sub(r'(\d+)\'(\d+)', r'\1\2', csv)
     return csv_url, csv, main_url


### PR DESCRIPTION
to fix column matching for the districts with "umlaut"